### PR TITLE
Specify container item for MilkBucket replacement

### DIFF
--- a/src/main/java/com/buuz135/industrial/module/ModuleCore.java
+++ b/src/main/java/com/buuz135/industrial/module/ModuleCore.java
@@ -14,6 +14,7 @@ import com.hrznstudio.titanium.module.Feature;
 import com.hrznstudio.titanium.tab.AdvancedTitaniumTab;
 import net.minecraft.block.Block;
 import net.minecraft.item.Item;
+import net.minecraft.item.Items;
 import net.minecraft.item.ItemGroup;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
@@ -101,7 +102,7 @@ public class ModuleCore implements IModule {
         features.add(Feature.builder("milk").content(TitaniumFluidInstance.class, MILK));
         features.add(Feature.builder("milk_bucket_replacement")
                 .description("If enabled the minecraft bucket item will be replaced with bucket that contains IF milk")
-                .content(Item.class, new MilkBucketItem(() -> ModuleCore.MILK.getSourceFluid(), new Item.Properties().maxStackSize(1).group(ItemGroup.MISC)).setRegistryName("minecraft", "milk_bucket")));
+                .content(Item.class, new MilkBucketItem(() -> ModuleCore.MILK.getSourceFluid(), new Item.Properties().maxStackSize(1).containerItem(Items.BUCKET).group(ItemGroup.MISC)).setRegistryName("minecraft", "milk_bucket")));
         TAB_CORE.addIconStack(new ItemStack(PLASTIC));
         return features;
     }


### PR DESCRIPTION
Forgive me if this fails to compile, as I've done it (horribly) from the browser in a rush. 

This fixes IF milk buckets used in recipes having the bucket deleted when used in recipes rather than returned as per usual. Item.containerItem is actually defined through properties rather than through a function, and the default BucketItem does (obviously) no longer specify this.