### PR TITLE
Update LaserBaseTile.java

### DIFF
--- a/src/main/java/com/buuz135/industrial/tile/world/LaserBaseTile.java
+++ b/src/main/java/com/buuz135/industrial/tile/world/LaserBaseTile.java
@@ -178,6 +178,7 @@ public class LaserBaseTile extends CustomSidedTileEntity implements IHasDisplayS
                 ) {
                     if (!entry.getBlacklist().contains(this.getWorld().getBiome(this.getPos()))) {
                         int increase = 0;
+                        int divisor = 0;
                         for (int i = 0; i < lensItems.getSlots(); ++i) {
                             if (
                                     !lensItems.getStackInSlot(i).isEmpty()
@@ -187,13 +188,18 @@ public class LaserBaseTile extends CustomSidedTileEntity implements IHasDisplayS
                                             lensItems.getStackInSlot(i).getItem() instanceof LaserLensItem
                             ) {
                                 if (((LaserLensItem) lensItems.getStackInSlot(i).getItem()).isInverted()) {
-                                    increase -= BlockRegistry.laserBaseBlock.getLenseChanceIncrease();
+                                    divisor += 2;
                                 } else {
                                     increase += BlockRegistry.laserBaseBlock.getLenseChanceIncrease();
                                 }
                             }
                         }
-                        items.add(new ItemStackWeightedItem(entry.getStack(), entry.getWeight() + increase));
+                        if (divisor == 0) {
+                            items.add(new ItemStackWeightedItem(entry.getStack(), entry.getWeight() + increase));
+                        }
+                        else {
+                            items.add(new ItemStackWeightedItem(entry.getStack(), entry.getWeight() / divisor));
+                        }
                     }
                 }
             });


### PR DESCRIPTION
With inverted lenses negative values would cause a server crash (see also #612 ).
So instead of substracting the weights, they are now divided by 2*n, where n is the number of lenses.
The result is that the possibility decreases without going below zero.

PS: #677 this fixes the crash, but with it the inverted lenses don't work anymore, so you won't get any blocks