### PR TITLE
Fix Resourceful Furnace not filling with Essence

### DIFF
--- a/src/main/java/com/buuz135/industrial/block/resourceproduction/tile/ResourcefulFurnaceTile.java
+++ b/src/main/java/com/buuz135/industrial/block/resourceproduction/tile/ResourcefulFurnaceTile.java
@@ -51,7 +51,7 @@ public class ResourcefulFurnaceTile extends IndustrialProcessingTile<Resourceful
                 setRange(1, 3));
         addTank(this.tank = (SidedFluidTankComponent<ResourcefulFurnaceTile>) new SidedFluidTankComponent<ResourcefulFurnaceTile>("essence", ResourcefulFurnaceConfig.maxEssenceTankSize, 132, 20, 2).
                 setColor(DyeColor.LIME).
-                setTankAction(FluidTankComponent.Action.DRAIN));
+                setComponentHarness(this));
         this.recipes = new FurnaceRecipe[3];
         this.getPowerPerTick = ResourcefulFurnaceConfig.powerPerTick;
     }


### PR DESCRIPTION
Without this change the Resourceful Furnace is not filling up with Essence at all.

To be honest, I just looked at the Plant Gatherer and copied from there, as that one is actually working and filling with Sludge. 
I'm not sure if I broke something else by doing this, but I hope this at least helps you guys with a place to start.

I have no experience with mod development, but it was nice to see how easy it is to set up this project in Intellij. Great job on that!

I did test this via the "runClient" gradle target, and it seems to have fixed the issue. I am however able to put Essence back in the furnace, which is probably what this line was used to prevent.