### PR TITLE
Fixed biofuelgenerator from using fuel when its full of energy

### DIFF
--- a/src/main/java/com/buuz135/industrial/block/generator/tile/BiofuelGeneratorTile.java
+++ b/src/main/java/com/buuz135/industrial/block/generator/tile/BiofuelGeneratorTile.java
@@ -44,7 +44,7 @@ public class BiofuelGeneratorTile extends IndustrialGeneratorTile<BiofuelGenerat
 
     @Override
     public boolean canStart() {
-        return biofuel.getFluidAmount() > 0;
+        return biofuel.getFluidAmount() > 0 && this.getEnergyStorage().getEnergyStored() < this.getEnergyStorage().getMaxEnergyStored();
     }
 
     @Override


### PR DESCRIPTION
BioFuelGenerator now checks if it is full of power before it uses biofuel.
closes #830 