### PR TITLE
build.gradle fixed to work with Titanium 3.2.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -143,7 +143,7 @@ dependencies {
     if (findProject(':titanium') != null) {
         compile project(':titanium')
     } else {
-        compile fg.deobf (project.dependencies.create('com.hrznstudio:titanium:1.16.4-3.2.0'))
+        compile fg.deobf (project.dependencies.create('com.hrznstudio:titanium:1.16.4-3.2.1'))
     }
     //if (findProject(':workspace') == null) {
     compileOnly fg.deobf("mezz.jei:jei-1.16.3:7.6.0.49:api")


### PR DESCRIPTION
Couldn't build the jar because in 3.2.0 of Titanium in the EnergyStorageComponent class the componentHarness attribute was private but in version 3.2.1 it's protected