### PR TITLE
1.16: Add Osmium to Laser Drill recipes

### DIFF
--- a/src/generated/resources/data/industrialforegoing/recipes/laser_drill_ore/osmium.json
+++ b/src/generated/resources/data/industrialforegoing/recipes/laser_drill_ore/osmium.json
@@ -1,0 +1,62 @@
+{
+  "type": "forge:conditional",
+  "recipes": [
+    {
+      "conditions": [
+        {
+          "value": {
+            "tag": "forge:ores/osmium",
+            "type": "forge:tag_empty"
+          },
+          "type": "forge:not"
+        }
+      ],
+      "recipe": {
+        "output": {
+          "tag": "forge:ores/osmium"
+        },
+        "rarity": [
+          {
+            "whitelist": {},
+            "blacklist": {
+              "type": "minecraft:worldgen/biome",
+              "values": [
+                "minecraft:the_end",
+                "minecraft:the_void",
+                "minecraft:small_end_islands",
+                "minecraft:end_barrens",
+                "minecraft:end_highlands",
+                "minecraft:end_midlands"
+              ]
+            },
+            "depth_min": 5,
+            "depth_max": 36,
+            "weight": 8
+          },
+          {
+            "whitelist": {},
+            "blacklist": {
+              "type": "minecraft:worldgen/biome",
+              "values": [
+                "minecraft:the_end",
+                "minecraft:the_void",
+                "minecraft:small_end_islands",
+                "minecraft:end_barrens",
+                "minecraft:end_highlands",
+                "minecraft:end_midlands"
+              ]
+            },
+            "depth_min": 0,
+            "depth_max": 255,
+            "weight": 2
+          }
+        ],
+        "pointer": 0,
+        "catalyst": {
+          "item": "industrialforegoing:laser_lens8"
+        },
+        "type": "industrialforegoing:laser_drill_ore"
+      }
+    }
+  ]
+}

--- a/src/main/java/com/buuz135/industrial/recipe/LaserDrillOreRecipe.java
+++ b/src/main/java/com/buuz135/industrial/recipe/LaserDrillOreRecipe.java
@@ -84,6 +84,7 @@ public class LaserDrillOreRecipe extends SerializableRecipe {
         createWithDefault("arcane", 2, 45, 60, 3, 1);
         createWithDefault("bitumen", 15, 50, 60, 2, 1);
         createWithDefault("fluorite", 8, 15, 30, 6, 1);
+        createWithDefault("osmium", 8, 5, 36, 8, 1);
         createWithDefault("yellorite", 4, 15, 50, 3, 1);
     }
 


### PR DESCRIPTION
I just noticed that it wasn't generating when I ran out of it in Valhelsia 3. Whoops.

For those unaware, osmium is a critical ore used in Mekanism for the production of circuits, which are used to create practically all machines. Having it just as rare as tin lines up with about what Mekanism expects balance-wise.

Disclaimer: This commit is untested since I don't have a Forge workspace set up at the moment, but it's such a simple change I don't anticipate it'll cause any issues \</famouslastwords\>.