### PR TITLE
Fix Mob Crusher not killing adult AnimalEntities

### DIFF
--- a/src/main/java/com/buuz135/industrial/block/agriculturehusbandry/tile/MobCrusherTile.java
+++ b/src/main/java/com/buuz135/industrial/block/agriculturehusbandry/tile/MobCrusherTile.java
@@ -104,7 +104,7 @@ public class MobCrusherTile extends IndustrialAreaWorkingTile<MobCrusherTile> {
     public WorkAction work() {
         if (hasEnergy(MobCrusherConfig.powerPerOperation)) {
             List<MobEntity> mobs = this.world.getEntitiesWithinAABB(MobEntity.class, getWorkingArea().getBoundingBox()).stream().filter(mobEntity -> !(mobEntity instanceof AnimalEntity &&
-            !mobEntity.isChild()) && !mobEntity.isInvulnerable() && !(mobEntity instanceof WitherEntity && ((WitherEntity) mobEntity).getInvulTime() > 0)).collect(Collectors.toList());
+            mobEntity.isChild()) && !mobEntity.isInvulnerable() && !(mobEntity instanceof WitherEntity && ((WitherEntity) mobEntity).getInvulTime() > 0)).collect(Collectors.toList());
             if (mobs.size() > 0) {
                 MobEntity entity = mobs.get(0);
                 FakePlayer player = IndustrialForegoing.getFakePlayer(this.world);


### PR DESCRIPTION
Fixes #899 
Fixes #898

Tested in a test world. Does not kill child AnimalEntities but does kill adult AnimalEntities (as it's supposed to). 

Fixes the Rats issue because Rats are considered AnimalEntities.

IMO the Mob Crusher SHOULD kill child mobs and the real issue is that the Loot Table is being populated with adult mob drops for child mobs. I understand however that skipping child mobs is a much easier fix than that however.