### PR TITLE
Fix Ears Reward

### DIFF
--- a/src/main/java/com/buuz135/industrial/IndustrialForegoing.java
+++ b/src/main/java/com/buuz135/industrial/IndustrialForegoing.java
@@ -57,6 +57,8 @@ import net.minecraft.world.World;
 import net.minecraft.world.server.ServerWorld;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
+import net.minecraftforge.client.event.ModelRegistryEvent;
+import net.minecraftforge.client.model.ModelLoader;
 import net.minecraftforge.common.ForgeMod;
 import net.minecraftforge.common.util.FakePlayer;
 import net.minecraftforge.common.util.NonNullLazy;
@@ -98,7 +100,9 @@ public class IndustrialForegoing extends ModuleController {
 
     public IndustrialForegoing() {
         proxy = new CommonProxy();
-        DistExecutor.runWhenOn(Dist.CLIENT, () -> () -> EventManager.mod(FMLClientSetupEvent.class).process(fmlClientSetupEvent -> new ClientProxy().run()).subscribe());
+        DistExecutor.unsafeRunWhenOn(Dist.CLIENT, () -> () -> EventManager.mod(FMLClientSetupEvent.class).process(fmlClientSetupEvent -> new ClientProxy().run()).subscribe());
+        DistExecutor.unsafeRunWhenOn(Dist.CLIENT, () -> () -> EventManager.mod(ModelRegistryEvent.class).process(modelRegistryEvent -> ModelLoader.addSpecialModel(new ResourceLocation(Reference.MOD_ID, "block/catears"))).subscribe());
+
         EventManager.mod(FMLCommonSetupEvent.class).process(fmlCommonSetupEvent -> proxy.run()).subscribe();
         EventManager.forge(FMLServerStartingEvent.class).process(fmlServerStartingEvent -> worldFakePlayer.clear()).subscribe();
         EventManager.modGeneric(RegistryEvent.Register.class, IRecipeSerializer.class)

--- a/src/main/java/com/buuz135/industrial/proxy/client/ClientProxy.java
+++ b/src/main/java/com/buuz135/industrial/proxy/client/ClientProxy.java
@@ -57,7 +57,6 @@ import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.text.StringTextComponent;
 import net.minecraft.util.text.TextFormatting;
 import net.minecraftforge.client.event.ModelBakeEvent;
-import net.minecraftforge.client.model.ModelLoader;
 import net.minecraftforge.client.model.obj.OBJModel;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.util.Constants;
@@ -96,7 +95,6 @@ public class ClientProxy extends CommonProxy {
 
 
         MinecraftForge.EVENT_BUS.register(new IFClientEvents());
-        ModelLoader.addSpecialModel(new ResourceLocation(Reference.MOD_ID, "block/catears"));
 
         EventManager.mod(ModelBakeEvent.class).process(event -> {
             ears_baked = event.getModelRegistry().get(new ResourceLocation(Reference.MOD_ID, "block/catears"));


### PR DESCRIPTION
ModelLoader.addSpecialModel must be called at the proper time - during or before the ModelRegistryEvent, so that the game is able to bake and cache the model. 

ClientProxy.run is called during FMLClientSetupEvent, which is fired AFTER all of the registry events, including ModelRegistryEvent, so previously the model was not baked in time.   
There is a race condition related to this, however, that may allow it to bake before the models are cached. This is non-deterministic, however.

I moved the code to a dedicated unsafeRunWhenOn block, using the EventManager system to subscribe the ModelLoader line to the proper event, so that it may run consistently.   
This fixes the ears reward, for me and possibly everyone else having issues with it.

I moved the nearby line to an unsafeRunWhenOn function, as the "normal" runWhenOn is deprecated and slated for removal soon. It is essentially the same function with extra checking for sanity.