### PR TITLE
Add Astral Sorcery plugin to allow Infinity Drill to mine Marble (#1008)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -151,6 +151,7 @@ dependencies {
     // at runtime, use the full JEI jar
     runtimeOnly fg.deobf("mezz.jei:jei-1.16.4:7.6.0.58")
     //}
+    compileOnly fg.deobf("curse.maven:astral-sorcery-241721:3156477")
     compileOnly fg.deobf("blusunrize.immersiveengineering:ImmersiveEngineering:1.16.3-4.1.0-+")
     compileOnly fg.deobf("vazkii.patchouli:Patchouli:1.16.2+:api")
     runtimeOnly fg.deobf("vazkii.patchouli:Patchouli:1.16.2+")

--- a/src/main/java/com/buuz135/industrial/plugin/AstralSorceryPlugin.java
+++ b/src/main/java/com/buuz135/industrial/plugin/AstralSorceryPlugin.java
@@ -1,0 +1,18 @@
+package com.buuz135.industrial.plugin;
+
+import com.buuz135.industrial.item.infinity.item.ItemInfinityDrill;
+import com.hrznstudio.titanium.annotation.plugin.FeaturePlugin;
+import com.hrznstudio.titanium.plugin.FeaturePluginInstance;
+import com.hrznstudio.titanium.plugin.PluginPhase;
+import hellfirepvp.astralsorcery.common.lib.MaterialsAS;
+import org.apache.commons.lang3.ArrayUtils;
+
+@FeaturePlugin(value = "astralsorcery", type = FeaturePlugin.FeaturePluginType.MOD)
+public class AstralSorceryPlugin implements FeaturePluginInstance {
+    @Override
+    public void execute(PluginPhase phase) {
+        if (phase == PluginPhase.COMMON_SETUP) {
+            ItemInfinityDrill.mineableMaterials = ArrayUtils.addAll(ItemInfinityDrill.mineableMaterials, MaterialsAS.MARBLE, MaterialsAS.BLACK_MARBLE);
+        }
+    }
+}


### PR DESCRIPTION
Added a FeaturePlugin for Astral Sorcery to allow the Infinity Drill to mine marble and black marble. Tested with AstralSorcery-1.16.4-1.13.9

This adds a compile-time dependency for AstralSorcery-1.16.4-1.13.9 from cursemaven.com

Replacing the materials array feels a bit hacky; not sure if this is the desired approach to implementing this.