### PR TITLE
Add a null check for IBlockColor parameters

### DIFF
--- a/src/main/java/com/buuz135/industrial/proxy/client/ClientProxy.java
+++ b/src/main/java/com/buuz135/industrial/proxy/client/ClientProxy.java
@@ -187,7 +187,7 @@ public class ClientProxy extends CommonProxy {
             return 0xFFFFFF;
         }, ModuleTool.INFINITY_BACKPACK);
         Minecraft.getInstance().getBlockColors().register((state, worldIn, pos, tintIndex) -> {
-            if (tintIndex == 0 && worldIn.getTileEntity(pos) instanceof BlackHoleTankTile) {
+            if (tintIndex == 0 && world != null && pos != null && worldIn.getTileEntity(pos) instanceof BlackHoleTankTile) {
                 BlackHoleTankTile tank = (BlackHoleTankTile) worldIn.getTileEntity(pos);
                 if (tank != null && tank.getTank().getFluidAmount() > 0) {
                     int color = FluidUtils.getFluidColor(tank.getTank().getFluid());


### PR DESCRIPTION
When calling `BlockRenderDispatcher#renderBlock` it calls the function `IBlockColor#getColor` with `null` for both the world and blockpos parameters.
The registered `IBlockColor` instance currently results in a null pointer exception in this case.

With my mod Entangled, I try rendering other blocks inside the entangled block using `BlockRenderDispatcher#renderBlock`.
Thus running into the issue.

I propose adding a null check for the mentioned parameters as they are annotated with `@Nullable`.