### PR TITLE
Voided Black Hole Unit overflowing once at max size

### DIFF
--- a/src/main/java/com/buuz135/industrial/block/transportstorage/tile/BlackHoleUnitTile.java
+++ b/src/main/java/com/buuz135/industrial/block/transportstorage/tile/BlackHoleUnitTile.java
@@ -278,12 +278,11 @@ public class BlackHoleUnitTile extends BHTile<BlackHoleUnitTile> {
         public ItemStack insertItem(int slot, @Nonnull ItemStack stack, boolean simulate) {
             if (isItemValid(slot, stack)) {
                 int inserted = Math.min(this.amount - stored, stack.getCount());
-                if (voidItems) inserted = stack.getCount();
                 if (!simulate){
                     setStack(stack);
                     setAmount(Math.min(stored + inserted, amount));
                 }
-                if (inserted == stack.getCount()) return ItemStack.EMPTY;
+                if (inserted == stack.getCount() || voidItems) return ItemStack.EMPTY;
                 return ItemHandlerHelper.copyStackWithSize(stack, stack.getCount() - inserted);
             }
             return stack;


### PR DESCRIPTION
This fixes the issue described in #1093.

With the Void Items enabled, the BHU would cause the amount to overflow, as once it is at its max, void would still attempt to insert more in.

If there was a better way to prevent this, I'm happy to refactor the fix.