### PR TITLE
Fluid fixes [black hole tank rendering and ore meat buckets]

### DIFF
--- a/src/main/java/com/buuz135/industrial/block/transportstorage/tile/BlackHoleTankTile.java
+++ b/src/main/java/com/buuz135/industrial/block/transportstorage/tile/BlackHoleTankTile.java
@@ -88,7 +88,11 @@ public class BlackHoleTankTile extends BHTile<BlackHoleTankTile> {
 
     @Override
     public ItemStack getDisplayStack() {
-        return tank.getFluidAmount() > 0 ? FluidUtil.getFilledBucket(tank.getFluid()) : new ItemStack(Items.BUCKET);
+        if (tank.getFluidAmount() > 0) {
+            ItemStack filledBucket = FluidUtil.getFilledBucket(tank.getFluid());
+            if(!filledBucket.isEmpty()) return filledBucket;
+        }
+        return new ItemStack(Items.BUCKET);
     }
 
     @Override

--- a/src/main/java/com/buuz135/industrial/fluid/OreFluidInstance.java
+++ b/src/main/java/com/buuz135/industrial/fluid/OreFluidInstance.java
@@ -7,13 +7,13 @@
 
 package com.buuz135.industrial.fluid;
 
+import com.buuz135.industrial.item.OreBucketItem;
 import com.hrznstudio.titanium.module.api.IAlternativeEntries;
 import com.hrznstudio.titanium.module.api.RegistryManager;
 import net.minecraft.block.Block;
 import net.minecraft.block.FlowingFluidBlock;
 import net.minecraft.block.material.Material;
 import net.minecraft.fluid.Fluid;
-import net.minecraft.item.BucketItem;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemGroup;
 import net.minecraft.item.Items;
@@ -34,7 +34,7 @@ public class OreFluidInstance extends net.minecraftforge.registries.ForgeRegistr
         this.sourceFluid = this.sourceFluid.setSourceFluid(sourceFluid).setFlowingFluid(flowingFluid);
         this.flowingFluid = this.flowingFluid.setSourceFluid(sourceFluid).setFlowingFluid(flowingFluid);
         if (hasBucket)
-            this.bucketFluid = new BucketItem(this.sourceFluid, new Item.Properties().containerItem(Items.BUCKET).maxStackSize(1).group(group)).setRegistryName(modid, fluid + "_bucket");
+            this.bucketFluid = new OreBucketItem(this::getSourceFluid, new Item.Properties().containerItem(Items.BUCKET).maxStackSize(1).group(group)).setRegistryName(modid, fluid + "_bucket");
         this.blockFluid = new FlowingFluidBlock(sourceFluid, Block.Properties.create(Material.WATER).doesNotBlockMovement().hardnessAndResistance(100.0F).noDrops()) {
         }.setRegistryName(modid, fluid + "_block");
         this.sourceFluid.setBlockFluid(blockFluid).setBucketFluid(bucketFluid);

--- a/src/main/java/com/buuz135/industrial/fluid/OreTitaniumFluidAttributes.java
+++ b/src/main/java/com/buuz135/industrial/fluid/OreTitaniumFluidAttributes.java
@@ -80,4 +80,14 @@ public class OreTitaniumFluidAttributes extends FluidAttributes {
         String tag = getFluidTag(stack);
         return TagUtil.getItemWithPreference(TagCollectionManager.getManager().getItemTags().get(new ResourceLocation(tag.replace("forge:ores/", "forge:dusts/"))));
     }
+
+    @Override
+    public ItemStack getBucket(FluidStack stack) {
+        ItemStack bucket = super.getBucket(stack);
+        if(stack.hasTag() && stack.getTag().contains(NBT_TAG)) {
+            String tag = stack.getTag().getString(NBT_TAG);
+            bucket.getOrCreateTag().putString(NBT_TAG, tag);
+        }
+        return bucket;
+    }
 }

--- a/src/main/java/com/buuz135/industrial/item/OreBucketItem.java
+++ b/src/main/java/com/buuz135/industrial/item/OreBucketItem.java
@@ -1,0 +1,93 @@
+package com.buuz135.industrial.item;
+
+import mcp.MethodsReturnNonnullByDefault;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.fluid.Fluid;
+import net.minecraft.item.BucketItem;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.CompoundNBT;
+import net.minecraft.tags.TagCollectionManager;
+import net.minecraft.util.ActionResult;
+import net.minecraft.util.Hand;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.text.ITextComponent;
+import net.minecraft.util.text.TranslationTextComponent;
+import net.minecraft.world.World;
+import net.minecraftforge.common.capabilities.ICapabilityProvider;
+import net.minecraftforge.fluids.FluidAttributes;
+import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.fluids.capability.wrappers.FluidBucketWrapper;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+import java.util.List;
+import java.util.function.Supplier;
+
+@ParametersAreNonnullByDefault
+@MethodsReturnNonnullByDefault
+public class OreBucketItem extends BucketItem {
+
+    private static final String NBT_TAG = "Tag";
+
+    public OreBucketItem(Supplier<? extends Fluid> supplier, Properties builder) {
+        super(supplier, builder);
+    }
+
+    @Override
+    public ActionResult<ItemStack> onItemRightClick(World world, PlayerEntity player, Hand hand) {
+        ItemStack stack = player.getHeldItem(hand);
+        if (stack.hasTag() && stack.getTag().contains(NBT_TAG)) return ActionResult.resultPass(stack);
+        return super.onItemRightClick(world, player, hand);
+    }
+
+    @Override
+    public ICapabilityProvider initCapabilities(ItemStack stack, @Nullable CompoundNBT nbt) {
+        return new FluidBucketWrapper(stack) {
+            @Nonnull
+            @Override
+            public FluidStack getFluid() {
+                FluidStack stack = new FluidStack(OreBucketItem.this.getFluid(), FluidAttributes.BUCKET_VOLUME);
+                if (container.getOrCreateTag().contains(NBT_TAG)) {
+                    String tag = container.getOrCreateTag().getString(NBT_TAG);
+                    stack.getOrCreateTag().putString(NBT_TAG, tag);
+                }
+                return stack;
+            }
+        };
+    }
+
+    @Override
+    public ITextComponent getDisplayName(ItemStack stack) {
+        TranslationTextComponent displayName = new TranslationTextComponent(this.getTranslationKey(stack));
+        if (stack.hasTag() && stack.getTag().contains(NBT_TAG)) {
+            String tag = stack.getTag().getString(NBT_TAG);
+            List<Item> items = TagCollectionManager.getManager().getItemTags().getTagByID(new ResourceLocation(tag)).getAllElements();
+            if (items.size() > 0) {
+                TranslationTextComponent oreDisplayName = new TranslationTextComponent(items.get(0).getTranslationKey());
+                return displayName.appendString(" (").append(oreDisplayName).appendString(")");
+            }
+        }
+        return displayName;
+    }
+
+    /*
+    This will not work  due to problems with how forge tags interact with the creative search initialization.
+    @Override
+    public void fillItemGroup(ItemGroup group, NonNullList<ItemStack> items) {
+        if (this.isInGroup(group)) {
+            items.add(new ItemStack(this));
+            ITagCollection<Item> tags = TagCollectionManager.getManager().getItemTags();
+            for (ResourceLocation loc : tags.getIDTagMap().keySet()) {
+                String tagName = loc.toString();
+                if (!tagName.startsWith("forge:ores/"))
+                    continue;
+                ItemStack stack = new ItemStack(this);
+                stack.getOrCreateTag().putString(NBT_TAG, tagName);
+                items.add(stack);
+            }
+        }
+    }
+     */
+}

--- a/src/main/java/com/buuz135/industrial/proxy/client/ClientProxy.java
+++ b/src/main/java/com/buuz135/industrial/proxy/client/ClientProxy.java
@@ -206,6 +206,16 @@ public class ClientProxy extends CommonProxy {
             }
             return 0xFFFFFF;
         },ModuleTransportStorage.BLACK_HOLE_TANK_COMMON, ModuleTransportStorage.BLACK_HOLE_TANK_PITY, ModuleTransportStorage.BLACK_HOLE_TANK_SIMPLE, ModuleTransportStorage.BLACK_HOLE_TANK_ADVANCED, ModuleTransportStorage.BLACK_HOLE_TANK_SUPREME);
+        Minecraft.getInstance().getItemColors().register((stack, tintIndex) -> {
+            if (tintIndex == 1 && stack.getCapability(CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY).isPresent()) {
+                IFluidHandlerItem fluidHandlerItem = stack.getCapability(CapabilityFluidHandler.FLUID_HANDLER_ITEM_CAPABILITY).orElseGet(null);
+                if (fluidHandlerItem.getFluidInTank(0).getAmount() > 0){
+                    int color = FluidUtils.getFluidColor(fluidHandlerItem.getFluidInTank(0));
+                    if (color != -1) return color;
+                }
+            }
+            return 0xFFFFFF;
+        }, ModuleCore.RAW_ORE_MEAT.getBucketFluid(), ModuleCore.FERMENTED_ORE_MEAT.getBucketFluid());
 
         RenderingRegistry.registerEntityRenderingHandler(ModuleTool.TRIDENT_ENTITY_TYPE, InfinityTridentRenderer::new);
 

--- a/src/main/java/com/buuz135/industrial/utils/ColorUtils.java
+++ b/src/main/java/com/buuz135/industrial/utils/ColorUtils.java
@@ -25,6 +25,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.texture.AtlasTexture;
 import net.minecraft.client.renderer.texture.Texture;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
+import net.minecraft.util.ColorHelper;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
@@ -46,39 +47,19 @@ public class ColorUtils {
         if (sprite == null) return -1;
         if (sprite.getFrameCount() == 0) return -1;
         float total = 0, red = 0, blue = 0, green = 0;
+        for (int x = 0; x < sprite.getWidth(); x++) {
             for (int y = 0; y < sprite.getHeight(); y++) {
-                for (int x = 0; x < sprite.getWidth(); x++) {
-                    int color = sprite.getPixelRGBA(0, x, y);
-                    if ((color >> 24 & 0xFF) != 255) continue;
-                    ++total;
-                    red +=  (color >> 0) & 0xFF;
-                    green += (color >>  8) & 0xFF;
-                    blue += (color >> 16) & 0xFF;
-                }
-            }
-
-        if (total > 0) return new Color( (int)(red / total), (int) (green / total), (int) (blue / total), 255).getRGB();
-        return -1;
-    }
-
-    public static int getColorFrom(TextureAtlasSprite sprite, Color filter) {
-        if (sprite == null) return -1;
-        if (sprite.getFrameCount() == 0) return -1;
-        int total = 0, red = 0, blue = 0, green = 0;
-        for (int y = 0; y < sprite.getHeight(); y++) {
-            for (int x = 0; x < sprite.getWidth(); x++) {
                 int color = sprite.getPixelRGBA(0, x, y);
-                if ((color >> 24 & 0xFF) != 255) continue;
-                Color temp = new Color((color >> 0) & 0xFF, (color >>  8) & 0xFF, (color >> 16) & 0xFF, color >> 24 & 0xFF);
-                if ((temp.getRGB() - filter.getRGB() < 500 && temp.getRGB() - filter.getRGB() > 500)) continue;
-                ++total;
-                red +=  (color >> 0) & 0xFF;
-                green += (color >>  8) & 0xFF;
-                blue += (color >> 16) & 0xFF;
+                int alpha = color >> 24 & 0xFF;
+                // if (alpha != 255) continue; // this creates problems for translucent textures
+                total += alpha;
+                red += (color & 0xFF) * alpha;
+                green += (color >> 8 & 0xFF) * alpha;
+                blue += (color >> 16 & 0xFF) * alpha;
             }
         }
-        if (total > 0) return new Color(red / total, green / total, blue / total, 255).brighter().getRGB();
+
+        if (total > 0) return ColorHelper.PackedColor.packColor( 255, (int)(red / total), (int) (green / total), (int) (blue / total));
         return -1;
     }
-
 }

--- a/src/main/java/com/buuz135/industrial/utils/FluidUtils.java
+++ b/src/main/java/com/buuz135/industrial/utils/FluidUtils.java
@@ -22,29 +22,29 @@
 package com.buuz135.industrial.utils;
 
 import net.minecraft.fluid.Fluid;
+import net.minecraft.util.ColorHelper;
+import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.fluids.FluidStack;
 
 import java.util.HashMap;
 
 public class FluidUtils {
-
-    public static HashMap<Fluid, Integer> colorCache = new HashMap<>();
+    // TODO
+    // should item colors from ItemStackUtils also be cached?
+    // invalidate cache on resource reload
+    public static HashMap<ResourceLocation, Integer> colorCache = new HashMap<>();
 
     public static int getFluidColor(FluidStack stack) {
-        int color = 0xFFFFFF;
-        if (stack != null && stack.getFluid() != null) {
-            color = colorCache.getOrDefault(stack.getFluid().getAttributes().getStillTexture(stack), stack.getFluid().getAttributes().getColor(stack) != 0xffffffff ? stack.getFluid().getAttributes().getColor(stack) : ColorUtils.getColorFrom(stack.getFluid().getAttributes().getStillTexture(stack)));
-            if (!colorCache.containsKey(stack.getFluid())) colorCache.put(stack.getFluid(), color);
-        }
-        return color;
+        ResourceLocation location = stack.getFluid().getAttributes().getStillTexture(stack);
+        int tint = stack.getFluid().getAttributes().getColor(stack);
+        int textureColor = colorCache.computeIfAbsent(location, ColorUtils::getColorFrom);
+        return ColorHelper.PackedColor.blendColors(textureColor, tint);
     }
 
     public static int getFluidColor(Fluid fluid) {
-        int color = 0xFFFFFF;
-        if (fluid != null) {
-            color = colorCache.getOrDefault(fluid, fluid.getAttributes().getColor() != 0xffffffff ? fluid.getAttributes().getColor() : ColorUtils.getColorFrom(fluid.getAttributes().getStillTexture()));
-            if (!colorCache.containsKey(fluid)) colorCache.put(fluid, color);
-        }
-        return color;
+        ResourceLocation location = fluid.getAttributes().getStillTexture();
+        int tint = fluid.getAttributes().getColor();
+        int textureColor = colorCache.computeIfAbsent(location, ColorUtils::getColorFrom);
+        return ColorHelper.PackedColor.blendColors(textureColor, tint);
     }
 }

--- a/src/main/java/com/buuz135/industrial/utils/ItemStackUtils.java
+++ b/src/main/java/com/buuz135/industrial/utils/ItemStackUtils.java
@@ -75,7 +75,7 @@ public class ItemStackUtils {
 
     @OnlyIn(Dist.CLIENT)
     public static int getColor(ItemStack stack) {
-        return ColorUtils.getColorFrom(Minecraft.getInstance().getItemRenderer().getItemModelWithOverrides(stack, Minecraft.getInstance().world, Minecraft.getInstance().player).getParticleTexture(), Color.GRAY);
+        return ColorUtils.getColorFrom(Minecraft.getInstance().getItemRenderer().getItemModelWithOverrides(stack, Minecraft.getInstance().world, Minecraft.getInstance().player).getParticleTexture());
     }
 
     public static void renderItemIntoGUI(MatrixStack matrixStack, ItemStack stack, int x, int y) {


### PR DESCRIPTION
- Black Hole Tanks would previously not correctly render certain fluids that had translucent non-grayscale textures, and would not render either a bucket or a quantity for fluids that have no filled bucket. I fixed the color code, and also made it use an empty bucket when there is no bucket.
- Ore Meat would lose the NBT tag when put in a bucket [in all contexts, including filling a bucket in IF itself, in other mods, or the bucket displayed on a black hole tank]. Fixing this required a custom bucket item and fluid handler class, since Forge provides no support for NBT with standard bucket items.

Implementation notes: This patch does not prevent NBT-less ore meat from being created in all contexts, and it doesn't prevent problems caused by trying to process NBT-less ore meat. There's no way to prevent creating it with commands, obviously, and I also haven't done anything about JEI or the creative menu. Ore meat can no longer be placed in the world unless it has no NBT tag [it would always lose the tag when placed in the world].