### PR TITLE
Two small potential performance boosts

### DIFF
--- a/src/main/java/com/buuz135/industrial/block/agriculturehusbandry/tile/PlantGathererTile.java
+++ b/src/main/java/com/buuz135/industrial/block/agriculturehusbandry/tile/PlantGathererTile.java
@@ -37,6 +37,7 @@ import com.hrznstudio.titanium.component.fluid.SidedFluidTankComponent;
 import com.hrznstudio.titanium.component.inventory.SidedInventoryComponent;
 import net.minecraft.item.DyeColor;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.math.BlockPos;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.capability.IFluidHandler;
 import net.minecraftforge.items.ItemHandlerHelper;
@@ -73,13 +74,14 @@ public class PlantGathererTile extends IndustrialAreaWorkingTile<PlantGathererTi
         if (hasEnergy(powerPerOperation)) {
             int amount = Math.max(1, BlockUtils.getBlockPosInAABB(getWorkingArea().getBoundingBox()).size() / 4);
             for (int i = 0; i < amount; i++) {
-                if (isLoaded(getPointedBlockPos()) && !ItemStackUtils.isInventoryFull(output)) {
-                    Optional<PlantRecollectable> optional = IFRegistries.PLANT_RECOLLECTABLES_REGISTRY.getValues().stream().filter(plantRecollectable -> plantRecollectable.canBeHarvested(this.world, getPointedBlockPos(), this.world.getBlockState(getPointedBlockPos()))).findFirst();
+                BlockPos pointed = getPointedBlockPos();
+                if (isLoaded(pointed) && !ItemStackUtils.isInventoryFull(output)) {
+                    Optional<PlantRecollectable> optional = IFRegistries.PLANT_RECOLLECTABLES_REGISTRY.getValues().stream().filter(plantRecollectable -> plantRecollectable.canBeHarvested(this.world, pointed, this.world.getBlockState(pointed))).findFirst();
                     if (optional.isPresent()) {
-                        List<ItemStack> drops = optional.get().doHarvestOperation(this.world, getPointedBlockPos(), this.world.getBlockState(getPointedBlockPos()));
+                        List<ItemStack> drops = optional.get().doHarvestOperation(this.world, pointed, this.world.getBlockState(pointed));
                         tank.fill(new FluidStack(ModuleCore.SLUDGE.getSourceFluid(), 10 * drops.size()), IFluidHandler.FluidAction.EXECUTE);
                         drops.forEach(stack -> ItemHandlerHelper.insertItem(output, stack, false));
-                        if (optional.get().shouldCheckNextPlant(this.world, getPointedBlockPos(), this.world.getBlockState(getPointedBlockPos()))) {
+                        if (optional.get().shouldCheckNextPlant(this.world, pointed, this.world.getBlockState(pointed))) {
                             increasePointer();
                         }
                         return new WorkAction(0.3f, powerPerOperation);

--- a/src/main/java/com/buuz135/industrial/block/resourceproduction/tile/BlockBreakerTile.java
+++ b/src/main/java/com/buuz135/industrial/block/resourceproduction/tile/BlockBreakerTile.java
@@ -35,6 +35,7 @@ import net.minecraft.item.DyeColor;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
 import net.minecraft.util.Hand;
+import net.minecraft.util.math.BlockPos;
 import net.minecraftforge.common.util.FakePlayer;
 import net.minecraftforge.items.ItemHandlerHelper;
 
@@ -60,17 +61,18 @@ public class BlockBreakerTile extends IndustrialAreaWorkingTile<BlockBreakerTile
     @Override
     public WorkAction work() {
         if (hasEnergy(getPowerPerOperation)) {
-            if (isLoaded(getPointedBlockPos()) && !world.isAirBlock(getPointedBlockPos()) && BlockUtils.canBlockBeBroken(this.world, getPointedBlockPos())) {
-                FakePlayer fakePlayer = IndustrialForegoing.getFakePlayer(this.world, getPointedBlockPos());
+            BlockPos pointed = getPointedBlockPos();
+            if (isLoaded(pointed) && !world.isAirBlock(pointed) && BlockUtils.canBlockBeBroken(this.world, pointed)) {
+                FakePlayer fakePlayer = IndustrialForegoing.getFakePlayer(this.world, pointed);
                 fakePlayer.setHeldItem(Hand.MAIN_HAND, new ItemStack(Items.DIAMOND_PICKAXE));
-                if (this.world.getBlockState(this.getPointedBlockPos()).getBlockHardness(this.world, this.getPointedBlockPos()) >= 0 && this.world.getBlockState(getPointedBlockPos()).canHarvestBlock(this.world, getPointedBlockPos(), fakePlayer)) {
-                    for (ItemStack blockDrop : BlockUtils.getBlockDrops(this.world, getPointedBlockPos())) {
+                if (this.world.getBlockState(pointed).getBlockHardness(this.world, pointed) >= 0 && this.world.getBlockState(pointed).canHarvestBlock(this.world, pointed, fakePlayer)) {
+                    for (ItemStack blockDrop : BlockUtils.getBlockDrops(this.world, pointed)) {
                         ItemStack result = ItemHandlerHelper.insertItem(output, blockDrop, false);
                         if (!result.isEmpty()) {
-                            BlockUtils.spawnItemStack(result, this.world, getPointedBlockPos());
+                            BlockUtils.spawnItemStack(result, this.world, pointed);
                         }
                     }
-                    this.world.setBlockState(getPointedBlockPos(), Blocks.AIR.getDefaultState());
+                    this.world.setBlockState(pointed, Blocks.AIR.getDefaultState());
                     increasePointer();
                     return new WorkAction(1, getPowerPerOperation);
                 }

--- a/src/main/java/com/buuz135/industrial/block/resourceproduction/tile/BlockPlacerTile.java
+++ b/src/main/java/com/buuz135/industrial/block/resourceproduction/tile/BlockPlacerTile.java
@@ -32,6 +32,7 @@ import com.hrznstudio.titanium.component.energy.EnergyStorageComponent;
 import com.hrznstudio.titanium.component.inventory.SidedInventoryComponent;
 import net.minecraft.item.BlockItem;
 import net.minecraft.item.DyeColor;
+import net.minecraft.util.math.BlockPos;
 
 import javax.annotation.Nonnull;
 
@@ -55,11 +56,12 @@ public class BlockPlacerTile extends IndustrialAreaWorkingTile<BlockPlacerTile> 
     @Override
     public WorkAction work() {
         if (hasEnergy(getPowerPerOperation)) {
-            if (isLoaded(getPointedBlockPos()) && world.isAirBlock(getPointedBlockPos())) {
+            BlockPos pointed = getPointedBlockPos();
+            if (isLoaded(pointed) && world.isAirBlock(pointed)) {
                 for (int i = 0; i < input.getSlots(); i++) {
                     if (!input.getStackInSlot(i).isEmpty() && input.getStackInSlot(i).getItem() instanceof BlockItem) {
-                        IFFakePlayer fakePlayer = (IFFakePlayer) IndustrialForegoing.getFakePlayer(world, getPointedBlockPos());
-                        if (fakePlayer.placeBlock(this.world, getPointedBlockPos(), input.getStackInSlot(i))) {
+                        IFFakePlayer fakePlayer = (IFFakePlayer) IndustrialForegoing.getFakePlayer(world, pointed);
+                        if (fakePlayer.placeBlock(this.world, pointed, input.getStackInSlot(i))) {
                             increasePointer();
                             return new WorkAction(1, getPowerPerOperation);
                         }

--- a/src/main/java/com/buuz135/industrial/block/resourceproduction/tile/FluidCollectorTile.java
+++ b/src/main/java/com/buuz135/industrial/block/resourceproduction/tile/FluidCollectorTile.java
@@ -34,6 +34,7 @@ import net.minecraft.block.Blocks;
 import net.minecraft.fluid.Fluid;
 import net.minecraft.item.DyeColor;
 import net.minecraft.state.properties.BlockStateProperties;
+import net.minecraft.util.math.BlockPos;
 import net.minecraftforge.fluids.FluidAttributes;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.capability.IFluidHandler;
@@ -62,13 +63,14 @@ public class FluidCollectorTile extends IndustrialAreaWorkingTile<FluidCollector
     @Override
     public WorkAction work() {
         if (hasEnergy(getPowerPerOperation)) {
-            if (isLoaded(getPointedBlockPos()) && !world.isAirBlock(getPointedBlockPos()) && BlockUtils.canBlockBeBroken(this.world, getPointedBlockPos()) && world.getFluidState(getPointedBlockPos()).isSource()) {
-                Fluid fluid = world.getFluidState(getPointedBlockPos()).getFluid();
+            BlockPos pointed = getPointedBlockPos();
+            if (isLoaded(pointed) && !world.isAirBlock(pointed) && BlockUtils.canBlockBeBroken(this.world, pointed) && world.getFluidState(pointed).isSource()) {
+                Fluid fluid = world.getFluidState(pointed).getFluid();
                 if (tank.isEmpty() || (tank.getFluid().getFluid().isEquivalentTo(fluid) && tank.getFluidAmount() + FluidAttributes.BUCKET_VOLUME <= tank.getCapacity())) {
-                    if (world.getBlockState(getPointedBlockPos()).hasProperty(BlockStateProperties.WATERLOGGED)) { //has
-                        world.setBlockState(getPointedBlockPos(), world.getBlockState(getPointedBlockPos()).with(BlockStateProperties.WATERLOGGED, false));
+                    if (world.getBlockState(pointed).hasProperty(BlockStateProperties.WATERLOGGED)) { //has
+                        world.setBlockState(pointed, world.getBlockState(pointed).with(BlockStateProperties.WATERLOGGED, false));
                     } else {
-                        world.setBlockState(getPointedBlockPos(), Blocks.AIR.getDefaultState());
+                        world.setBlockState(pointed, Blocks.AIR.getDefaultState());
                     }
                     tank.fillForced(new FluidStack(fluid, FluidAttributes.BUCKET_VOLUME), IFluidHandler.FluidAction.EXECUTE);
                     increasePointer();

--- a/src/main/java/com/buuz135/industrial/block/resourceproduction/tile/FluidPlacerTile.java
+++ b/src/main/java/com/buuz135/industrial/block/resourceproduction/tile/FluidPlacerTile.java
@@ -33,6 +33,7 @@ import com.hrznstudio.titanium.component.fluid.SidedFluidTankComponent;
 import net.minecraft.fluid.Fluids;
 import net.minecraft.item.DyeColor;
 import net.minecraft.state.properties.BlockStateProperties;
+import net.minecraft.util.math.BlockPos;
 import net.minecraftforge.fluids.FluidAttributes;
 import net.minecraftforge.fluids.capability.IFluidHandler;
 
@@ -60,14 +61,15 @@ public class FluidPlacerTile extends IndustrialAreaWorkingTile<FluidPlacerTile> 
     @Override
     public WorkAction work() {
         if (hasEnergy(getPowerPerOperation)) {
-            if (isLoaded(getPointedBlockPos()) && BlockUtils.canBlockBeBroken(this.world, getPointedBlockPos()) && !world.getFluidState(getPointedBlockPos()).isSource() && tank.getFluidAmount() >= FluidAttributes.BUCKET_VOLUME) {
-                if (tank.getFluid().getFluid().isEquivalentTo(Fluids.WATER) && world.getBlockState(getPointedBlockPos()).hasProperty(BlockStateProperties.WATERLOGGED) && !world.getBlockState(getPointedBlockPos()).get(BlockStateProperties.WATERLOGGED)) {
-                    world.setBlockState(getPointedBlockPos(), world.getBlockState(getPointedBlockPos()).with(BlockStateProperties.WATERLOGGED, true));
+            BlockPos pointed = getPointedBlockPos();
+            if (isLoaded(pointed) && BlockUtils.canBlockBeBroken(this.world, pointed) && !world.getFluidState(pointed).isSource() && tank.getFluidAmount() >= FluidAttributes.BUCKET_VOLUME) {
+                if (tank.getFluid().getFluid().isEquivalentTo(Fluids.WATER) && world.getBlockState(pointed).hasProperty(BlockStateProperties.WATERLOGGED) && !world.getBlockState(pointed).get(BlockStateProperties.WATERLOGGED)) {
+                    world.setBlockState(pointed, world.getBlockState(pointed).with(BlockStateProperties.WATERLOGGED, true));
                     tank.drainForced(FluidAttributes.BUCKET_VOLUME, IFluidHandler.FluidAction.EXECUTE);
                     increasePointer();
                     return new WorkAction(1, getPowerPerOperation);
-                } else if (world.isAirBlock(getPointedBlockPos())) {
-                    world.setBlockState(getPointedBlockPos(), tank.getFluid().getFluid().getDefaultState().getBlockState());
+                } else if (world.isAirBlock(pointed)) {
+                    world.setBlockState(pointed, tank.getFluid().getFluid().getDefaultState().getBlockState());
                     tank.drainForced(FluidAttributes.BUCKET_VOLUME, IFluidHandler.FluidAction.EXECUTE);
                     increasePointer();
                     return new WorkAction(1, getPowerPerOperation);

--- a/src/main/java/com/buuz135/industrial/block/resourceproduction/tile/FluidPlacerTile.java
+++ b/src/main/java/com/buuz135/industrial/block/resourceproduction/tile/FluidPlacerTile.java
@@ -68,7 +68,7 @@ public class FluidPlacerTile extends IndustrialAreaWorkingTile<FluidPlacerTile> 
                     tank.drainForced(FluidAttributes.BUCKET_VOLUME, IFluidHandler.FluidAction.EXECUTE);
                     increasePointer();
                     return new WorkAction(1, getPowerPerOperation);
-                } else if (world.isAirBlock(pointed) || !world.getFluidState(getPointedBlockPos()).isSource()) {
+                } else if (world.isAirBlock(pointed) || !world.getFluidState(pointed).isSource()) {
                     world.setBlockState(pointed, tank.getFluid().getFluid().getDefaultState().getBlockState());
                     tank.drainForced(FluidAttributes.BUCKET_VOLUME, IFluidHandler.FluidAction.EXECUTE);
                     increasePointer();

--- a/src/main/java/com/buuz135/industrial/utils/BlockUtils.java
+++ b/src/main/java/com/buuz135/industrial/utils/BlockUtils.java
@@ -55,7 +55,7 @@ import java.util.List;
 public class BlockUtils {
 
     public static List<BlockPos> getBlockPosInAABB(AxisAlignedBB axisAlignedBB) {
-        List<BlockPos> blocks = new ArrayList<BlockPos>();
+        List<BlockPos> blocks = new ArrayList<>();
         for (double y = axisAlignedBB.minY; y < axisAlignedBB.maxY; ++y) {
             for (double x = axisAlignedBB.minX; x < axisAlignedBB.maxX; ++x) {
                 for (double z = axisAlignedBB.minZ; z < axisAlignedBB.maxZ; ++z) {


### PR DESCRIPTION
This pull request introduces two changes to address some performance issues discovered in recent profiles of the official Enigmatica 6 server (see each individual issue descriptions for an example profile)

1. Avoid calling `getPointedBlockPos()` excessively in tile entities where possible (https://spark.lucko.me/jzsDC7KbEE):
Since `getPointedBlockPos()` **shouldn't** change over the course of a single work tick and calling it should be considered an expensive operation (mostly due to the underlying call to `BlockUtils#getBlockPosInAABB`, I've chosen to just cache it for the duration of the work tick where this wasn't the case already. The profile specifically shows the Plant Gatherer tiles causing a fair bit of tick lag, which is probably due to the fact that `getPointedBlockPos()` was being called inside a stream **for each plant and tick**, resulting in quite large amounts of overhead.

2. Cache the resolved input Ingredient for FluidExtractorRecipe (https://spark.lucko.me/tLQ5kjZhs1)
This is done to hopefully avoid unnecessary overhead in the `matches` function, which may be called once per tick per machine in a worst-case scenario, as previously, an Ingredient would be constructed and **immediately** dissolved, only to then be promptly discarded afterwards. I've decided to cache the input per recipe such that once it's been resolved once, it'll just reuse the existing Ingredient instead of creating a new one. Additionally, the field is marked as `transient` to hide it from the serializer

I'll probably keep digging through the Spark profiles I've gathered so far and see whether I can find other things that would be easy to address in this PR, but other than that, these two changes should hopefully already increase performance significantly ^^