### PR TITLE
Fix crash on network error

### DIFF
--- a/src/main/java/com/buuz135/industrial/IndustrialForegoing.java
+++ b/src/main/java/com/buuz135/industrial/IndustrialForegoing.java
@@ -119,7 +119,7 @@ public class IndustrialForegoing extends ModuleController {
                     registerReward();
                 }
             }, new String[]{"normal"}));
-        } catch (MalformedURLException e) {
+        } catch (Exception e) {
             LOGGER.catching(e);
         }
         LaserDrillRarity.init();


### PR DESCRIPTION
Various types of exceptions will be thrown when trying to open a connection, not only MalformedURLException.