### PR TITLE
Add AgriCraft Compatibility to Plant Interactor

### DIFF
--- a/src/main/java/com/buuz135/industrial/tile/agriculture/PlantInteractorTile.java
+++ b/src/main/java/com/buuz135/industrial/tile/agriculture/PlantInteractorTile.java
@@ -48,6 +48,9 @@ import net.minecraftforge.items.ItemStackHandler;
 import net.ndrei.teslacorelib.inventory.BoundingRectangle;
 import net.ndrei.teslacorelib.inventory.FluidTankType;
 
+import com.infinityraider.agricraft.api.v1.misc.IAgriHarvestable;
+import net.minecraft.tileentity.TileEntity;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -86,6 +89,13 @@ public class PlantInteractorTile extends WorkingAreaElectricMachine {
                 BlockPos tempPos = new BlockPos(pointerPos.getX(), pointerPos.getY() + i, pointerPos.getZ());
                 if (!BlockUtils.canBlockBeBroken(this.world, tempPos)) continue;
                 IBlockState tempState = this.world.getBlockState(tempPos);
+                TileEntity te = world.getTileEntity(tempPos);
+                if (te instanceof IAgriHarvestable) {
+			        WORKING_TILES.add(this);
+			        ((IAgriHarvestable)te).onHarvest(stack -> ItemHandlerHelper.insertItem(outItems, stack, false), null);
+			        WORKING_TILES.remove(this);
+                    continue;
+                }
                 if (tempState.getBlock() instanceof IPlantable || tempState.getBlock() instanceof IGrowable) {
                     FakePlayer player = IndustrialForegoing.getFakePlayer(this.world, tempPos.up());
                     player.inventory.clear();


### PR DESCRIPTION
Changed it so the Plant Interactor will take AgriCraft crops directly into its inventory, removing the HORRENDOUS lag with large AgriCraft farms in modpacks.  The two primary sources of lag are grief protection plugins with FakePlayers and creating item drops in the world, both of which are remedied by this change.

This fix is already implemented in the Divine Journey 2 modpack via Mixin.