### PR TITLE
1.16 Fix to BlackHoleControllerTile

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -147,8 +147,8 @@ repositories {
 
 dependencies {
     minecraft 'net.minecraftforge:forge:1.16.5-36.2.8'
-    compileOnly fg.deobf ('com.hrznstudio:titanium:1.16.5-3.2.8.2')
-    runtimeOnly fg.deobf ('com.hrznstudio:titanium:1.16.5-3.2.8.2')
+    compileOnly fg.deobf ('curse.maven:titanium-287342:3346366')
+    runtimeOnly fg.deobf ('curse.maven:titanium-287342:3346366')
     //if (findProject(':workspace') == null) {
     compileOnly fg.deobf("mezz.jei:jei-1.16.5:7.7.1.121:api")
     // at runtime, use the full JEI jar

--- a/src/main/java/com/buuz135/industrial/block/transportstorage/tile/BlackHoleControllerTile.java
+++ b/src/main/java/com/buuz135/industrial/block/transportstorage/tile/BlackHoleControllerTile.java
@@ -135,7 +135,7 @@ public class BlackHoleControllerTile extends ActiveTile<BlackHoleControllerTile>
             ItemStack bl = units_storage.getStackInSlot(slot);
             if (!bl.isEmpty() && bl.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY).isPresent()){
                 IItemHandler handler = bl.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY).orElse(null);
-                return handler.extractItem(0, amount, simulate);
+                return handler.extractItem(0, amount, false);
             }
             return ItemStack.EMPTY;
         }

--- a/src/main/java/com/buuz135/industrial/capability/BLHBlockItemHandlerItemStack.java
+++ b/src/main/java/com/buuz135/industrial/capability/BLHBlockItemHandlerItemStack.java
@@ -81,7 +81,7 @@ public class BLHBlockItemHandlerItemStack implements IItemHandler {
             ItemStack out = blStack.copy();
             int newAmount = stored;
             if (!simulate) {
-                //setStack(ItemStack.EMPTY);
+                setStack(ItemStack.EMPTY);
                 setAmount(0);
             }
             out.setCount(newAmount);


### PR DESCRIPTION
Fixes the Black Hole Controller to reset its ghost item to EMPTY once emptied.