### PR TITLE
PlantInteractor AgriCraft Integration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -96,6 +96,10 @@ dependencies {
     compileOnly "CraftTweaker2:CraftTweaker2-MC1120-Main:1.12-4.0.10.306"
     deobfCompile "baubles:Baubles:1.12:1.5.2"
     deobfCompile "moo-fluids:MooFluids:1.12.2:1.7.11.02a"
+    compileOnly(
+            fg.deobf("curse.maven:AgriCraft-225635:3317747"),
+            fg.deobf("curse.maven:InfinityLib-251396:3317119")
+    )
 }
 
 processResources {

--- a/src/main/java/com/buuz135/industrial/tile/agriculture/PlantInteractorTile.java
+++ b/src/main/java/com/buuz135/industrial/tile/agriculture/PlantInteractorTile.java
@@ -48,6 +48,8 @@ import net.minecraftforge.items.ItemStackHandler;
 import net.ndrei.teslacorelib.inventory.BoundingRectangle;
 import net.ndrei.teslacorelib.inventory.FluidTankType;
 
+import com.infinityraider.agricraft.api.v1.misc.IAgriHarvestable;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -86,7 +88,18 @@ public class PlantInteractorTile extends WorkingAreaElectricMachine {
                 BlockPos tempPos = new BlockPos(pointerPos.getX(), pointerPos.getY() + i, pointerPos.getZ());
                 if (!BlockUtils.canBlockBeBroken(this.world, tempPos)) continue;
                 IBlockState tempState = this.world.getBlockState(tempPos);
-                if (tempState.getBlock() instanceof IPlantable || tempState.getBlock() instanceof IGrowable) {
+                TileEntity te = world.getTileEntity(tempPos);
+                if (te instanceof IAgriHarvestable) {
+                    WORKING_TILES.add(this);
+                    ((IAgriHarvestable)te).onHarvest(stack -> {
+                        if (!stack.isEmpty()) {
+                            ItemHandlerHelper.insertItem(outItems, stack, false);
+                            sludge.fill(new FluidStack(FluidsRegistry.SLUDGE, 10 * stack.getCount()), true);
+                            hasWorked = true;
+                        }
+                    }, null);
+                    WORKING_TILES.remove(this);
+                } else if (tempState.getBlock() instanceof IPlantable || tempState.getBlock() instanceof IGrowable) {
                     FakePlayer player = IndustrialForegoing.getFakePlayer(this.world, tempPos.up());
                     player.inventory.clear();
                     WORKING_TILES.add(this);


### PR DESCRIPTION
Fixes lag caused by massive AgriCraft farms dropping their contents onto the floor by making AC crops put their drops directly into the PI's inventory.