### PR TITLE
Fix issue with Mob Imprisonment Tool with filter matching

### DIFF
--- a/src/main/java/com/buuz135/industrial/proxy/block/filter/ItemStackFilter.java
+++ b/src/main/java/com/buuz135/industrial/proxy/block/filter/ItemStackFilter.java
@@ -53,7 +53,7 @@ public class ItemStackFilter extends AbstractFilter<Entity> {
         for (GhostSlot stack : this.getFilter()) {
             if (entity instanceof ItemEntity && stack.getStack().sameItem(((ItemEntity) entity).getItem()))
                 return true;
-            if (entity instanceof LivingEntity && stack.getStack().getItem().equals(ModuleTool.MOB_IMPRISONMENT_TOOL) && ((MobImprisonmentToolItem)ModuleTool.MOB_IMPRISONMENT_TOOL.get()).containsEntity(stack.getStack())
+            if (entity instanceof LivingEntity && stack.getStack().getItem().getRegistryName().equals(ModuleTool.MOB_IMPRISONMENT_TOOL.get().getRegistryName()) && ((MobImprisonmentToolItem)ModuleTool.MOB_IMPRISONMENT_TOOL.get()).containsEntity(stack.getStack())
                     && entity.getType().getRegistryName().toString().equalsIgnoreCase(((MobImprisonmentToolItem)ModuleTool.MOB_IMPRISONMENT_TOOL.get()).getID(stack.getStack()))) {
                 return true;
             }


### PR DESCRIPTION
Fix issue between Mob Imprisonment tool not getting registered correctly when attempting to be matched by a filter.