### PR TITLE
Fix bug which made ore laser not honor Titaniums mod preference list

### DIFF
--- a/src/generated/resources/data/industrialforegoing/recipes/laser_drill_ore/raw_materials/cobalt.json
+++ b/src/generated/resources/data/industrialforegoing/recipes/laser_drill_ore/raw_materials/cobalt.json
@@ -5,7 +5,7 @@
       "conditions": [
         {
           "value": {
-            "tag": "forge:ores/raw_materials/cobalt",
+            "tag": "forge:raw_materials/cobalt",
             "type": "forge:tag_empty"
           },
           "type": "forge:not"
@@ -13,7 +13,7 @@
       ],
       "recipe": {
         "output": {
-          "tag": "forge:ores/raw_materials/cobalt"
+          "tag": "forge:raw_materials/cobalt"
         },
         "rarity": [
           {

--- a/src/main/java/com/buuz135/industrial/block/resourceproduction/tile/OreLaserBaseTile.java
+++ b/src/main/java/com/buuz135/industrial/block/resourceproduction/tile/OreLaserBaseTile.java
@@ -154,7 +154,7 @@ public class OreLaserBaseTile extends IndustrialMachineTile<OreLaserBaseTile> im
                         for (int i = 0; i < lens.getSlots(); i++) {
                             if (laserDrillOreRecipe.catalyst.test(lens.getStackInSlot(i))) weight += OreLaserBaseConfig.catalystModifier;
                         }
-                        ItemStack stack = laserDrillOreRecipe.output.getItems()[0];
+                        ItemStack stack = ItemStack.EMPTY;
                         for (String modid : TagConfig.ITEM_PREFERENCE) {
                             for (ItemStack matchingStack : laserDrillOreRecipe.output.getItems()) {
                                 if (matchingStack.getItem().getRegistryName().getNamespace().equals(modid)){
@@ -162,7 +162,9 @@ public class OreLaserBaseTile extends IndustrialMachineTile<OreLaserBaseTile> im
                                     break;
                                 }
                             }
+                            if (!stack.isEmpty()) break;
                         }
+                        if (stack.isEmpty()) stack = laserDrillOreRecipe.output.getItems()[0];
                         return new ItemStackWeightedItem(stack.copy(), weight);
                     }).collect(Collectors.toList());
             if (!items.isEmpty()){


### PR DESCRIPTION
IF was not honoring the mod priority list for returned items.  The actual behavior was to return something farther down on the list o not on the list at all.  Also fixed an incorrect tag in the Raw Cobalt recipe.

Fix bug which made ore laser not honor Titaniums mod preference list
Fix tags in Raw Cobalt recipe