### PR TITLE
Fix for whilelist-only ores (including Ancient Debris) not being mined by the ore laser

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -150,7 +150,7 @@ repositories {
 }
 
 dependencies {
-    minecraft 'net.minecraftforge:forge:1.19.2-43.1.13'
+    minecraft 'net.minecraftforge:forge:1.19.2-43.1.43'
     //compileOnly fg.deobf("mezz.jei:jei-1.18.2:9.5.5.174")
     // at runtime, use the full JEI jar
     compileOnly fg.deobf("mezz.jei:jei-1.19.1-common-api:11.2.0.241")
@@ -162,6 +162,7 @@ dependencies {
     compileOnly fg.deobf("top.theillusivec4.curios:curios-forge:${curios_mc_version}-${curios_version}:api")
     runtimeOnly fg.deobf("top.theillusivec4.curios:curios-forge:${curios_mc_version}-${curios_version}")
     //runtimeOnly fg.deobf("curse.maven:immersive-engineering-231951:3755665")
+    runtimeOnly fg.deobf("mekanism:Mekanism:${mekanism_version}")// core
 
     // compiled from github
     //compileOnly fg.deobf("vazkii.patchouli:Patchouli:1.17.1-56-SNAPSHOT:api")

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,3 +5,4 @@ minecraftVersion=1.19.2
 api_version=3.3.2.0
 curios_mc_version=1.19.2
 curios_version=5.1.1.0
+mekanism_version=1.19.2-10.3.5.474

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Fixed an incorrect `ResourceLocation` lookup, which produced nulls and caused `getValidRarity` to fail for "heavily whitelisted" items.

This should fix https://github.com/InnovativeOnlineIndustries/Industrial-Foregoing/issues/1305 and similar issues.

Also, bumped gradle version and added Mekanism for easier testing.