### PR TITLE
Laserdrill compat to Extreme Reactors

### DIFF
--- a/src/generated/resources/data/industrialforegoing/recipes/laser_drill_ore/ores/cinnabar.json
+++ b/src/generated/resources/data/industrialforegoing/recipes/laser_drill_ore/ores/cinnabar.json
@@ -1,0 +1,62 @@
+{
+  "type": "forge:conditional",
+  "recipes": [
+    {
+      "conditions": [
+        {
+          "type": "forge:not",
+          "value": {
+            "type": "forge:tag_empty",
+            "tag": "forge:ores/cinnabar"
+          }
+        }
+      ],
+      "recipe": {
+        "type": "industrialforegoing:laser_drill_ore",
+        "catalyst": {
+          "item": "industrialforegoing:laser_lens14"
+        },
+        "output": {
+          "tag": "forge:ores/cinnabar"
+        },
+        "pointer": 0,
+        "rarity": [
+          {
+            "blacklist": {
+              "type": "minecraft:worldgen/biome",
+              "values": [
+                "minecraft:the_end",
+                "minecraft:the_void",
+                "minecraft:small_end_islands",
+                "minecraft:end_barrens",
+                "minecraft:end_highlands",
+                "minecraft:end_midlands"
+              ]
+            },
+            "depth_max": 70,
+            "depth_min": 30,
+            "weight": 2,
+            "whitelist": {}
+          },
+          {
+            "blacklist": {
+              "type": "minecraft:worldgen/biome",
+              "values": [
+                "minecraft:the_end",
+                "minecraft:the_void",
+                "minecraft:small_end_islands",
+                "minecraft:end_barrens",
+                "minecraft:end_highlands",
+                "minecraft:end_midlands"
+              ]
+            },
+            "depth_max": 255,
+            "depth_min": 0,
+            "weight": 1,
+            "whitelist": {}
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/src/generated/resources/data/industrialforegoing/recipes/laser_drill_ore/ores/yellorite.json
+++ b/src/generated/resources/data/industrialforegoing/recipes/laser_drill_ore/ores/yellorite.json
@@ -1,0 +1,62 @@
+{
+  "type": "forge:conditional",
+  "recipes": [
+    {
+      "conditions": [
+        {
+          "type": "forge:not",
+          "value": {
+            "type": "forge:tag_empty",
+            "tag": "forge:ores/yellorite"
+          }
+        }
+      ],
+      "recipe": {
+        "type": "industrialforegoing:laser_drill_ore",
+        "catalyst": {
+          "item": "industrialforegoing:laser_lens4"
+        },
+        "output": {
+          "tag": "forge:ores/yellorite"
+        },
+        "pointer": 0,
+        "rarity": [
+          {
+            "blacklist": {
+              "type": "minecraft:worldgen/biome",
+              "values": [
+                "minecraft:the_end",
+                "minecraft:the_void",
+                "minecraft:small_end_islands",
+                "minecraft:end_barrens",
+                "minecraft:end_highlands",
+                "minecraft:end_midlands"
+              ]
+            },
+            "depth_max": 50,
+            "depth_min": 15,
+            "weight": 3,
+            "whitelist": {}
+          },
+          {
+            "blacklist": {
+              "type": "minecraft:worldgen/biome",
+              "values": [
+                "minecraft:the_end",
+                "minecraft:the_void",
+                "minecraft:small_end_islands",
+                "minecraft:end_barrens",
+                "minecraft:end_highlands",
+                "minecraft:end_midlands"
+              ]
+            },
+            "depth_max": 255,
+            "depth_min": 0,
+            "weight": 1,
+            "whitelist": {}
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/src/main/java/com/buuz135/industrial/recipe/LaserDrillOreRecipe.java
+++ b/src/main/java/com/buuz135/industrial/recipe/LaserDrillOreRecipe.java
@@ -83,6 +83,7 @@ public class LaserDrillOreRecipe extends SerializableRecipe {
         createWithDefault("ores/sapphire", 11, 30, 70, 6, 1);
         createWithDefault("ores/peridot", 13, 30, 70, 6, 1);
         createWithDefault("ores/sodalite", 11, 30, 70, 6, 1);
+        createWithDefault("ores/yellorite", 4, 16, 68, 3, 1);
         createWithDefault("raw_materials/bauxite", 12, 50, 100, 6, 1);
         createWithDefault("raw_materials/pyrite", 12, 30, 70, 3, 1);
         createWithDefault("raw_materials/cinnabar", 14, 30, 70, 2, 1);

--- a/src/main/java/com/buuz135/industrial/recipe/LaserDrillOreRecipe.java
+++ b/src/main/java/com/buuz135/industrial/recipe/LaserDrillOreRecipe.java
@@ -84,6 +84,7 @@ public class LaserDrillOreRecipe extends SerializableRecipe {
         createWithDefault("ores/peridot", 13, 30, 70, 6, 1);
         createWithDefault("ores/sodalite", 11, 30, 70, 6, 1);
         createWithDefault("ores/yellorite", 4, 16, 68, 3, 1);
+        createWithDefault("ores/cinnabar", 14, 30, 70, 2, 1);
         createWithDefault("raw_materials/bauxite", 12, 50, 100, 6, 1);
         createWithDefault("raw_materials/pyrite", 12, 30, 70, 3, 1);
         createWithDefault("raw_materials/cinnabar", 14, 30, 70, 2, 1);


### PR DESCRIPTION
Added yellorite ore as a laser drill result. 
Extreme Reactors uses forge:ores/yellorite.