### PR TITLE
[1.20] Fix bug where Black Hole Units could transmute items

### DIFF
--- a/src/main/java/com/buuz135/industrial/block/transportstorage/tile/BlackHoleUnitTile.java
+++ b/src/main/java/com/buuz135/industrial/block/transportstorage/tile/BlackHoleUnitTile.java
@@ -240,6 +240,11 @@ public class BlackHoleUnitTile extends BHTile<BlackHoleUnitTile> {
 
     public void setStack(ItemStack stack) {
         boolean equal = ItemStack.isSameItemSameTags(stack, blStack);
+        if (!stack.isEmpty()) {
+            // Normalize the stack size, otherwise stacks larger than 127 can become empty when
+            // serialized.
+            stack = ItemHandlerHelper.copyStackWithSize(stack, 1);
+        }
         this.blStack = stack;
         this.hasNBT = this.blStack.hasTag();
         if (!equal) syncObject(this.blStack);

--- a/src/main/java/com/buuz135/industrial/capability/BLHBlockItemHandlerItemStack.java
+++ b/src/main/java/com/buuz135/industrial/capability/BLHBlockItemHandlerItemStack.java
@@ -146,6 +146,11 @@ public class BLHBlockItemHandlerItemStack implements IItemHandler {
             compoundNBT.put("BlockEntityTag", new CompoundTag());
             this.stack.setTag(compoundNBT);
         }
+        if (!stack.isEmpty()) {
+            // Normalize the stack size, otherwise stacks larger than 127 can become empty when
+            // serialized.
+            stack = ItemHandlerHelper.copyStackWithSize(stack, 1);
+        }
         this.stack.getTag().getCompound("BlockEntityTag").put("blStack", stack.serializeNBT());
     }
 


### PR DESCRIPTION
Fix a bug where Black Hole Units could accept arbitrary items and transmute the original items when the last insert operation had a size of 128 or larger.

Fixes #1399.
