### PR TITLE
Typo on the ore tag

### DIFF
--- a/src/generated/resources/data/industrialforegoing/recipes/laser_drill_ore/ores/draconium.json
+++ b/src/generated/resources/data/industrialforegoing/recipes/laser_drill_ore/ores/draconium.json
@@ -17,7 +17,7 @@
           "item": "industrialforegoing:laser_lens10"
         },
         "output": {
-          "tag": "forge:ores/ores/draconium"
+          "tag": "forge:ores/draconium"
         },
         "pointer": 0,
         "rarity": [


### PR DESCRIPTION
It appears to have a typo on the ore tag, this is preventing the generation of draconium and is generating empty tag barriers