### PR TITLE
Optimize JEI startup time

### DIFF
--- a/src/main/java/com/buuz135/industrial/plugin/jei/subtype/AddonSubtypeInterpreter.java
+++ b/src/main/java/com/buuz135/industrial/plugin/jei/subtype/AddonSubtypeInterpreter.java
@@ -1,16 +1,23 @@
 package com.buuz135.industrial.plugin.jei.subtype;
 
 import com.hrznstudio.titanium.item.AugmentWrapper;
-import mezz.jei.api.ingredients.subtypes.IIngredientSubtypeInterpreter;
+import mezz.jei.api.ingredients.subtypes.ISubtypeInterpreter;
 import mezz.jei.api.ingredients.subtypes.UidContext;
 import net.minecraft.world.item.ItemStack;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.HashMap;
 import java.util.Map;
 
-public class AddonSubtypeInterpreter implements IIngredientSubtypeInterpreter<ItemStack> {
+public class AddonSubtypeInterpreter implements ISubtypeInterpreter<ItemStack> {
+
     @Override
-    public String apply(ItemStack ingredient, UidContext context) {
+    public @Nullable Object getSubtypeData(ItemStack ingredient, UidContext context) {
+        return ingredient.get(AugmentWrapper.ATTACHMENT);
+    }
+
+    @Override
+    public String getLegacyStringSubtypeInfo(ItemStack ingredient, UidContext context) {
         Map<String, Float> attachment = ingredient.getOrDefault(AugmentWrapper.ATTACHMENT, new HashMap<>());
         var result = new StringBuilder();
         attachment.forEach((key, value) -> result.append(key).append("=").append(value).append('-'));

--- a/src/main/java/com/buuz135/industrial/plugin/jei/subtype/InfinitySubtypeInterpreter.java
+++ b/src/main/java/com/buuz135/industrial/plugin/jei/subtype/InfinitySubtypeInterpreter.java
@@ -1,13 +1,25 @@
 package com.buuz135.industrial.plugin.jei.subtype;
 
 import com.buuz135.industrial.utils.IFAttachments;
-import mezz.jei.api.ingredients.subtypes.IIngredientSubtypeInterpreter;
+import mezz.jei.api.ingredients.subtypes.ISubtypeInterpreter;
 import mezz.jei.api.ingredients.subtypes.UidContext;
 import net.minecraft.world.item.ItemStack;
+import org.jetbrains.annotations.Nullable;
 
-public class InfinitySubtypeInterpreter implements IIngredientSubtypeInterpreter<ItemStack> {
+import java.util.List;
+
+public class InfinitySubtypeInterpreter implements ISubtypeInterpreter<ItemStack> {
+
     @Override
-    public String apply(ItemStack ingredient, UidContext context) {
+    public @Nullable Object getSubtypeData(ItemStack ingredient, UidContext context) {
+        return List.of(
+            ingredient.getOrDefault(IFAttachments.INFINITY_ITEM_POWER, 0L),
+            ingredient.getOrDefault(IFAttachments.INFINITY_ITEM_SPECIAL, true)
+        );
+    }
+
+    @Override
+    public String getLegacyStringSubtypeInfo(ItemStack ingredient, UidContext context) {
         return ingredient.getOrDefault(IFAttachments.INFINITY_ITEM_POWER, 0L).toString() + "_" + ingredient.getOrDefault(IFAttachments.INFINITY_ITEM_SPECIAL, true).toString();
     }
 }

--- a/src/main/resources/META-INF/neoforge.mods.toml
+++ b/src/main/resources/META-INF/neoforge.mods.toml
@@ -79,3 +79,9 @@ mandatory = true #mandatory
 versionRange = "[3.2.8,)" #mandatory
 ordering = "NONE"
 side = "BOTH"
+[[dependencies."${mod_id}"]] #optional
+modId = "jei" #mandatory
+mandatory = false #mandatory
+versionRange = "[19.11.0,)" #mandatory
+ordering = "NONE"
+side = "CLIENT"


### PR DESCRIPTION
Happy [Modtoberfest](https://modtoberfest.com/)!

Tested against a big pack (ATM10)

Before (`industrialforegoing-1.21-3.6.13`): 
`Registering recipes: industrialforegoing:default took 865.1 milliseconds`

After: 
`Registering recipes: industrialforegoing:default took 166.8 milliseconds`


## How?

This builds a cache of 2x2 and 3x3 recipes where all ingredients are identical.
Building the cache is expensive but checking against them repeatedly pays off later.