### PR TITLE
Add `item_exists` condition to the guide recipe

### DIFF
--- a/src/main/resources/data/industrialforegoing/recipe/manual.json
+++ b/src/main/resources/data/industrialforegoing/recipe/manual.json
@@ -1,4 +1,10 @@
 {
+  "neoforge:conditions": [
+    {
+      "type": "neoforge:item_exists",
+      "item": "patchouli:guide_book"
+    }
+  ],
   "type": "minecraft:crafting_shapeless",
   "ingredients": [
     {


### PR DESCRIPTION
Currently when the mod is loaded without Patchouli the Guide recipe errors out because it expects the patchouli guide_book to exist. This PR adds the item_exists condition to ignore the recipe if it's missing.

This PR does the following:
* Add `neoforge:item_exists` condition to the guide recipe

Happy ModToberFest

![Cat gif](https://media1.tenor.com/m/JWFEQcWcJyQAAAAC/happy-catto-cats.gif)