### PR TITLE
Entity.RemovalReason change in MobImprisonmentToolItem.java

### DIFF
--- a/src/main/java/com/buuz135/industrial/item/MobImprisonmentToolItem.java
+++ b/src/main/java/com/buuz135/industrial/item/MobImprisonmentToolItem.java
@@ -82,7 +82,7 @@ public class MobImprisonmentToolItem extends IFCustomItem {
         nbt.putString("entity", EntityType.getKey(target.getType()).toString());
         target.saveWithoutId(nbt);
         stack.setTag(nbt);
-        target.remove(Entity.RemovalReason.KILLED);
+        target.remove(Entity.RemovalReason.DISCARDED);
         return true;
     }
 


### PR DESCRIPTION
DISCARDED is a more appropriate way to discard a mob instead of KILLED if it's not being killed and just being removed from the world. Helps with mods that perform certain actions on mobs if their removal reason is KILLED to not misbehave with the mob imprisonment tool.