### PR TITLE
Rework Transporter Logic

### DIFF
--- a/src/main/java/com/buuz135/industrial/api/transporter/FilteredTransporterType.java
+++ b/src/main/java/com/buuz135/industrial/api/transporter/FilteredTransporterType.java
@@ -21,14 +21,12 @@
  */
 package com.buuz135.industrial.api.transporter;
 
-import com.buuz135.industrial.IndustrialForegoing;
 import com.buuz135.industrial.api.IBlockContainer;
 import com.buuz135.industrial.api.conveyor.gui.IGuiComponent;
 import com.buuz135.industrial.gui.component.StateButtonInfo;
 import com.buuz135.industrial.gui.component.custom.RegulatorFilterGuiComponent;
 import com.buuz135.industrial.gui.component.custom.TexturedStateButtonGuiComponent;
 import com.buuz135.industrial.proxy.block.filter.RegulatorFilter;
-import com.buuz135.industrial.proxy.network.TransporterSyncMessage;
 import com.buuz135.industrial.utils.IFAttachments;
 import com.buuz135.industrial.utils.Reference;
 import net.minecraft.core.Direction;
@@ -42,14 +40,10 @@ import java.util.List;
 public abstract class FilteredTransporterType<TYPE, CAP> extends TransporterType {
 
     private RegulatorFilter<TYPE, CAP> filter;
-    private boolean whitelist;
-    private boolean isRegulated;
 
     public FilteredTransporterType(IBlockContainer container, TransporterTypeFactory factory, Direction side, TransporterTypeFactory.TransporterAction action) {
         super(container, factory, side, action);
         this.filter = createFilter();
-        this.whitelist = false;
-        this.isRegulated = false;
     }
 
     public boolean hasGui() {
@@ -57,76 +51,60 @@ public abstract class FilteredTransporterType<TYPE, CAP> extends TransporterType
     }
 
     public void handleButtonInteraction(int buttonId, CompoundTag compound) {
-        if (buttonId >= 0 && buttonId < filter.getFilter().length) {
+        if (buttonId >= 0 && buttonId < filter.getFilterSlots().length) {
             if (compound.contains("Amount")) {
-                this.filter.getFilter()[buttonId].increaseAmount(compound.getInt("Amount"));
+                this.filter.getFilterSlots()[buttonId].increaseAmount(compound.getInt("Amount"));
             } else {
                 this.filter.setFilter(buttonId, ItemStack.parseOptional(IFAttachments.registryAccess(), compound));
             }
             this.getContainer().requestSync();
         }
         if (buttonId == 16) {
-            whitelist = !whitelist;
+            this.filter.setWhitelisted(!filter.isWhitelisted());
             this.getContainer().requestSync();
         }
         if (buttonId == 17) {
-            isRegulated = !isRegulated;
+            this.filter.setRegulated(!filter.isRegulated());
             this.getContainer().requestSync();
         }
     }
 
     public abstract RegulatorFilter<TYPE, CAP> createFilter();
 
-    public void handleRenderSync(Direction origin, CompoundTag compoundNBT) {
-
-    }
-
-    public void syncRender(Direction origin, CompoundTag compoundNBT) {
-        IndustrialForegoing.NETWORK.sendToNearby(getLevel(), getPos(), 32, new TransporterSyncMessage(getPos(), compoundNBT, getSide().get3DDataValue(), origin.get3DDataValue()));
-    }
-
     public void addComponentsToGui(List<IGuiComponent> componentList) {
         super.addComponentsToGui(componentList);
+
         componentList.add(new RegulatorFilterGuiComponent(this.filter.getLocX(), this.filter.getLocY(), this.filter.getSizeX(), this.filter.getSizeY()) {
             @Override
             public RegulatorFilter<TYPE, CAP> getFilter() {
                 return FilteredTransporterType.this.filter;
             }
-
-            @Override
-            public boolean isRegulator() {
-                return isRegulated;
-            }
         });
+
         ResourceLocation res = ResourceLocation.fromNamespaceAndPath(Reference.MOD_ID, "textures/gui/machines.png");
         componentList.add(new TexturedStateButtonGuiComponent(16, 133, 20, 18, 18,
                 new StateButtonInfo(0, res, 1, 214, new String[]{"whitelist"}),
                 new StateButtonInfo(1, res, 20, 214, new String[]{"blacklist"})) {
             @Override
             public int getState() {
-                return whitelist ? 0 : 1;
+                return filter.isWhitelisted() ? 0 : 1;
             }
         });
+
         componentList.add(new TexturedStateButtonGuiComponent(17, 133, 40, 18, 18,
                 new StateButtonInfo(0, res, 58, 233, new String[]{"regulated_true"}),
                 new StateButtonInfo(1, res, 58 + 19, 233, new String[]{"regulated_false"})) {
             @Override
             public int getState() {
-                return isRegulated ? 0 : 1;
+                return filter.isRegulated() ? 0 : 1;
             }
         });
-    }
-
-    public boolean ignoresCollision() {
-        return false;
     }
 
     @Override
     public CompoundTag serializeNBT(HolderLookup.Provider provider) {
         CompoundTag compoundNBT = super.serializeNBT(provider);
         compoundNBT.put("Filter", filter.serializeNBT(provider));
-        compoundNBT.putBoolean("Whitelist", whitelist);
-        compoundNBT.putBoolean("Regulated", isRegulated);
         return compoundNBT;
     }
 
@@ -134,19 +112,9 @@ public abstract class FilteredTransporterType<TYPE, CAP> extends TransporterType
     public void deserializeNBT(HolderLookup.Provider provider, CompoundTag nbt) {
         super.deserializeNBT(provider, nbt);
         if (nbt.contains("Filter")) filter.deserializeNBT(provider, nbt.getCompound("Filter"));
-        whitelist = nbt.getBoolean("Whitelist");
-        isRegulated = nbt.getBoolean("Regulated");
     }
 
     public RegulatorFilter<TYPE, CAP> getFilter() {
         return filter;
-    }
-
-    public boolean isWhitelist() {
-        return whitelist;
-    }
-
-    public boolean isRegulated() {
-        return isRegulated;
     }
 }

--- a/src/main/java/com/buuz135/industrial/block/transportstorage/transporter/filter/FluidFilter.java
+++ b/src/main/java/com/buuz135/industrial/block/transportstorage/transporter/filter/FluidFilter.java
@@ -1,0 +1,102 @@
+package com.buuz135.industrial.block.transportstorage.transporter.filter;
+
+import com.buuz135.industrial.proxy.block.filter.IFilter;
+import com.buuz135.industrial.proxy.block.filter.RegulatorFilter;
+import net.neoforged.neoforge.fluids.FluidStack;
+import net.neoforged.neoforge.fluids.FluidUtil;
+import net.neoforged.neoforge.fluids.capability.IFluidHandler;
+import org.jetbrains.annotations.NotNull;
+
+public class FluidFilter extends RegulatorFilter<FluidStack, IFluidHandler> {
+    public FluidFilter(int locX, int locY, int sizeX, int sizeY, int smallMultiplier, int bigMultiplier, int maxAmount, String label) {
+        super(locX, locY, sizeX, sizeY, smallMultiplier, bigMultiplier, maxAmount, label);
+    }
+
+    /**
+     * Used to check if provided FluidStack matches the filter. This method ignores regulation rule.
+     *
+     * @param stack         FluidStack to check
+     * @param handler Capability of this filter.
+     * @return True if provided FluidStack matches, false otherwise.
+     */
+    @Override
+    public boolean matches(FluidStack stack, IFluidHandler handler) {
+        if (isEmpty()) return !isWhitelisted();
+
+        for (IFilter.GhostSlot slot : this.getFilterSlots()) {
+            FluidStack original = FluidUtil.getFluidContained(slot.getStack()).orElse(null);
+            if (original != null && FluidStack.isSameFluidSameComponents(original, stack)) return isWhitelisted();
+        }
+
+        return !isWhitelisted();
+    }
+
+    /**
+     * Used to get the amount to extract of the provided FluidStack.
+     *
+     * @param stack         FluidStack to check.
+     * @param handler Capability of this filter.
+     * @return Amount to extract, complying to the regulation rule.
+     */
+    @Override
+    public int getExtractAmount(FluidStack stack, IFluidHandler handler) {
+        if (!matches(stack, handler)) return 0;
+        if (isEmpty() || !isRegulated() || !isWhitelisted()) return stack.getAmount();
+
+        // Fluid - Minimum Left in storage (0 or above)
+        return Math.max(0, getStorageAmount(stack, handler) - getFilterAmount(stack));
+    }
+
+    /**
+     * Used to get the possible amount of FluidStack to insert.
+     *
+     * @param stack         FluidStack to check.
+     * @param handler Capability of this filter.
+     * @return Possible amount to insert, complying to the regulation rule.
+     */
+    @Override
+    public int getInsertAmount(FluidStack stack, IFluidHandler handler) {
+        if (!matches(stack, handler)) return 0;
+        if (isEmpty() || !isRegulated() || !isWhitelisted()) return stack.getAmount();
+
+        // Maximum amount in storage - items (0 or above)
+        return Math.max(0, getFilterAmount(stack) - getStorageAmount(stack, handler));
+    }
+
+    /**
+     * Used to get the amount of the item set in the filter. Checks all slots of the filter.
+     * @param stack Fluid to look for.
+     * @return Amount of the item.
+     * @apiNote If not Regulated, will return either 0 or 1.
+     */
+    public int getFilterAmount(FluidStack stack) {
+        int amount = 0;
+
+        for (IFilter.GhostSlot slot : this.getFilterSlots()) {
+            FluidStack original = FluidUtil.getFluidContained(slot.getStack()).orElse(null);
+            if (original != null && FluidStack.isSameFluidSameComponents(original, stack)) {
+                if (!isRegulated()) return 1;
+                amount += slot.getAmount();
+            }
+        }
+
+        return amount;
+    }
+
+    /**
+     * Used to get the amount of the item in the provided IFluidHandler.
+     * @param stack Fluid to look for.
+     * @return Amount of the item.
+     */
+    public int getStorageAmount(FluidStack stack, @NotNull IFluidHandler handler) {
+        int amount = 0;
+
+        for (int i = 0; i < handler.getTanks(); i++) {
+            if (handler.isFluidValid(i, stack) && FluidStack.isSameFluidSameComponents(handler.getFluidInTank(i), stack)) {
+                amount += handler.getFluidInTank(i).getAmount();
+            }
+        }
+
+        return amount;
+    }
+}

--- a/src/main/java/com/buuz135/industrial/block/transportstorage/transporter/filter/ItemFilter.java
+++ b/src/main/java/com/buuz135/industrial/block/transportstorage/transporter/filter/ItemFilter.java
@@ -1,0 +1,97 @@
+package com.buuz135.industrial.block.transportstorage.transporter.filter;
+
+import com.buuz135.industrial.proxy.block.filter.IFilter;
+import com.buuz135.industrial.proxy.block.filter.RegulatorFilter;
+import net.minecraft.world.item.ItemStack;
+import net.neoforged.neoforge.items.IItemHandler;
+import org.jetbrains.annotations.NotNull;
+
+public class ItemFilter extends RegulatorFilter<ItemStack, IItemHandler> {
+    public ItemFilter(int locX, int locY, int sizeX, int sizeY, int smallMultiplier, int bigMultiplier, int maxAmount, String label) {
+        super(locX, locY, sizeX, sizeY, smallMultiplier, bigMultiplier, maxAmount, label);
+    }
+
+    /**
+     * Used to check if provided ItemStack matches the filter. This method ignores regulation rule.
+     *
+     * @param stack ItemStack to check
+     * @param handler Capability of this filter.
+     * @return True if provided TYPE matches, false otherwise.
+     */
+    @Override
+    public boolean matches(ItemStack stack, IItemHandler handler) {
+        if (isEmpty()) return !isWhitelisted();
+
+        for (IFilter.GhostSlot slot : this.getFilterSlots())
+            if (ItemStack.isSameItem(slot.getStack(), stack)) return isWhitelisted();
+
+        return !isWhitelisted();
+    }
+
+    /**
+     * Used to get the amount to extract of the provided ItemStack.
+     *
+     * @param stack ItemStack to check.
+     * @param handler Capability of this filter.
+     * @return Amount to extract, complying to the regulation rule.
+     */
+    @Override
+    public int getExtractAmount(ItemStack stack, IItemHandler handler) {
+        if (!matches(stack, handler)) return 0;
+        if (isEmpty() || !isRegulated() || !isWhitelisted()) return stack.getCount();
+
+        // Items - Minimum Left in storage (0 or above)
+        return Math.max(0, getStorageAmount(stack, handler) - getFilterAmount(stack));
+    }
+
+    /**
+     * Used to get the possible amount of ItemStack to insert.
+     * @param stack ItemStack to check.
+     * @param handler Capability of this filter.
+     * @return Possible amount to insert, complying to the regulation rule.
+     * @implNote This method does not check for available space in the provided IItemHandler.
+     */
+    @Override
+    public int getInsertAmount(ItemStack stack, IItemHandler handler) {
+        if (!matches(stack, handler)) return 0;
+        if (isEmpty() || !isRegulated() || !isWhitelisted()) return stack.getCount();
+
+        // Maximum amount in storage - items (0 or above)
+        return Math.max(0, getFilterAmount(stack) - getStorageAmount(stack, handler));
+    }
+
+    /**
+     * Used to get the amount of the item set in the filter. Checks all slots of the filter.
+     * @param stack Item to look for.
+     * @return Amount of the item.
+     * @apiNote If not Regulated, will return either 0 or 1.
+     */
+    public int getFilterAmount(ItemStack stack) {
+        int amount = 0;
+
+        for (IFilter.GhostSlot slot : this.getFilterSlots()) {
+            if (ItemStack.isSameItem(slot.getStack(), stack)) {
+                if (!isRegulated()) return 1;
+                amount += slot.getAmount();
+            }
+        }
+
+        return amount;
+    }
+
+    /**
+     * Used to get the amount of the item in the provided IItemHandler.
+     * @param stack Item to look for.
+     * @return Amount of the item.
+     */
+    public int getStorageAmount(ItemStack stack, @NotNull IItemHandler handler) {
+        int amount = 0;
+
+        for (int i = 0; i < handler.getSlots(); i++) {
+            if (ItemStack.isSameItem(handler.getStackInSlot(i), stack))
+                amount += handler.getStackInSlot(i).getCount();
+        }
+
+        return amount;
+    }
+}

--- a/src/main/java/com/buuz135/industrial/gui/component/custom/RegulatorFilterGuiComponent.java
+++ b/src/main/java/com/buuz135/industrial/gui/component/custom/RegulatorFilterGuiComponent.java
@@ -102,13 +102,13 @@ public abstract class RegulatorFilterGuiComponent extends PositionedGuiComponent
                 int posX = guiX + getXPos() + x * 18;
                 int posY = guiY + getXPos() + i * 18;
                 guiGraphics.blit(BG_TEXTURE, posX, posY, 176, 0, 18, 18); //blit
-                if (!getFilter().getFilter()[pos].getStack().isEmpty()) {
-                    guiGraphics.renderItem(getFilter().getFilter()[pos].getStack(), posX + 1, posY + 1);
+                if (!getFilter().getFilterSlots()[pos].getStack().isEmpty()) {
+                    guiGraphics.renderItem(getFilter().getFilterSlots()[pos].getStack(), posX + 1, posY + 1);
                     if (isRegulator()) {
                         guiGraphics.pose().pushPose();
                         guiGraphics.pose().translate(0, 0, 260);
                         guiGraphics.pose().scale(0.5f, 0.5f, 0.5f);
-                        String amount = getFilter().getFilter()[pos].getAmount() + "";
+                        String amount = getFilter().getFilterSlots()[pos].getAmount() + "";
                         guiGraphics.drawString(Minecraft.getInstance().font, ChatFormatting.WHITE + amount, (int) ((posX + 17 - Minecraft.getInstance().font.width(amount) / 2f) * 2), (posY + 13) * 2, 0xFFFFFF);
                         guiGraphics.pose().popPose();
                     }
@@ -139,7 +139,9 @@ public abstract class RegulatorFilterGuiComponent extends PositionedGuiComponent
 
     public abstract RegulatorFilter getFilter();
 
-    public abstract boolean isRegulator();
+    public boolean isRegulator() {
+        return getFilter().isRegulated();
+    };
 
     @Nullable
     @Override
@@ -149,8 +151,8 @@ public abstract class RegulatorFilterGuiComponent extends PositionedGuiComponent
             for (int x = 0; x < getXSize(); x++) {
                 int posX = guiX + getXPos() + x * 18;
                 int posY = guiY + getXPos() + i * 18;
-                if (mouseX > posX + 1 && mouseX < posX + 1 + 16 && mouseY > posY + 1 && mouseY < posY + 1 + 16 && !getFilter().getFilter()[pos].getStack().isEmpty()) {
-                    List<Component> strings = Minecraft.getInstance().screen.getTooltipFromItem(Minecraft.getInstance(), getFilter().getFilter()[pos].getStack());
+                if (mouseX > posX + 1 && mouseX < posX + 1 + 16 && mouseY > posY + 1 && mouseY < posY + 1 + 16 && !getFilter().getFilterSlots()[pos].getStack().isEmpty()) {
+                    List<Component> strings = Minecraft.getInstance().screen.getTooltipFromItem(Minecraft.getInstance(), getFilter().getFilterSlots()[pos].getStack());
                     if (isRegulator())
                         strings.add(Component.literal(ChatFormatting.DARK_GRAY + "*Use Scroll Wheel to change*"));
                     return strings;


### PR DESCRIPTION
This PR reworks the Transporter Logic, fixing few bugs and adding new features!
It also slightly buffs all of the transporters.

### Changes
- Transporters now work in Regulate Mode on the Extraction side!
They will leave in the storage the amount of items specified in the filter.
- Regulate Mode affects only whitelist mode - it's ignored in blacklist mode.
- Efficiency is being calculated now with use of `Math.ceil(int)` instead of direct cast to `int`, fixing an issue that max transporters were able to handle "only" 63 of stuff per work cycle. (They now handle at max 64/t)
- Entire Filtering logic was moved to the RegulatorFilter class, including Whitelist and Regulate mode.
This makes it simpler to implement filters and later on - logic in the transporters, as all checks are handled by the filter.
- Blacklist now correctly passes all items (except blacklisted ones) on the insertion side.
- Fluid Transporerts now can handle 333,(3)mb/t without upgrades (16,(6)mb/t before), and 64 000mb/t with all tier 2 upgrades (3 200mb/t before)