### PR TITLE
DRY up latex bonus code, make "triple" display conditional.

### DIFF
--- a/src/main/java/com/buuz135/industrial/block/core/tile/FluidExtractorTile.java
+++ b/src/main/java/com/buuz135/industrial/block/core/tile/FluidExtractorTile.java
@@ -74,10 +74,13 @@ public class FluidExtractorTile extends IndustrialAreaWorkingTile<FluidExtractor
         if (isLoaded(pos) && !this.level.isEmptyBlock(pos) && this.tank.getFluidAmount() < this.tank.getCapacity()) {
             if (currentRecipe == null || !currentRecipe.matches(this.level, pos) || currentRecipe.defaultRecipe)
                 currentRecipe = findRecipe(this.level, pos);
+
             if (currentRecipe != null) {//GetDimensionType
+                boolean powered = hasEnergy(powerPerOperation);
+
                 FluidExtractionProgress extractionProgress = EXTRACTION.computeIfAbsent(this.level.dimensionType(), dimensionType -> new HashMap<>()).computeIfAbsent(this.level.getChunkAt(pos).getPos(), chunkPos -> new HashMap<>()).computeIfAbsent(pos, pos1 -> new FluidExtractionProgress(this.level));
-                if (currentRecipe.output.getFluid().isSame(ModuleCore.LATEX.getSourceFluid().get())) {
-                    tank.fillForced(new FluidStack(currentRecipe.output.getFluid(), currentRecipe.output.getAmount() * (hasEnergy(powerPerOperation) ? 3 : 1)), IFluidHandler.FluidAction.EXECUTE);
+                if (currentRecipe.outputsLatex()) {
+                    tank.fillForced(new FluidStack(currentRecipe.output.getFluid(), currentRecipe.output.getAmount() * (powered ? 3 : 1)), IFluidHandler.FluidAction.EXECUTE);
                 } else {
                     tank.fillForced(currentRecipe.output.copy(), IFluidHandler.FluidAction.EXECUTE);
                 }
@@ -87,11 +90,12 @@ public class FluidExtractorTile extends IndustrialAreaWorkingTile<FluidExtractor
                 if (extractionProgress.getProgress() > 7) {
                     extractionProgress.setProgress(0);
                     this.level.setBlockAndUpdate(pos, currentRecipe.result);
-                    if (currentRecipe.output.getFluid().isSame(ModuleCore.LATEX.getSourceFluid().get())) {
-                        tank.fillForced(new FluidStack(currentRecipe.output.getFluid(), currentRecipe.output.getAmount() * (hasEnergy(powerPerOperation) ? 200 : 1)), IFluidHandler.FluidAction.EXECUTE);
+                    if (currentRecipe.outputsLatex()) {
+                        tank.fillForced(new FluidStack(currentRecipe.output.getFluid(), currentRecipe.output.getAmount() * (powered ? 200 : 1)), IFluidHandler.FluidAction.EXECUTE);
                     }
                 }
-                if (hasEnergy(powerPerOperation)) return new WorkAction(0.4f, powerPerOperation);
+                if (powered)
+                    return new WorkAction(0.4f, powerPerOperation);
                 return new WorkAction(1f, 0);
             }
         }

--- a/src/main/java/com/buuz135/industrial/plugin/emi/recipe/FluidExtractorEmiRecipe.java
+++ b/src/main/java/com/buuz135/industrial/plugin/emi/recipe/FluidExtractorEmiRecipe.java
@@ -51,8 +51,10 @@ public class FluidExtractorEmiRecipe extends CustomEmiRecipe {
         widgets.addDrawable(0, 0, 0, 0, (draw, mouseX, mouseY, delta) -> {
             draw.drawString(Minecraft.getInstance().font, ChatFormatting.DARK_GRAY + Component.translatable("text.industrialforegoing.jei.recipe.production").getString(), 80, 6, 0xFFFFFF, false);
             draw.drawString(Minecraft.getInstance().font, ChatFormatting.DARK_GRAY + "" + recipe.value().output.getAmount() + Component.translatable("text.industrialforegoing.jei.recipe.mb_work").getString(), 80, 6 + (Minecraft.getInstance().font.lineHeight + 2) * 1, 0xFFFFFF, false);
-            draw.drawString(Minecraft.getInstance().font, ChatFormatting.DARK_AQUA + "" + Component.translatable("text.industrialforegoing.jei.recipe.tripled_when").getString(), 80, 6 + (Minecraft.getInstance().font.lineHeight + 2) * 2, 0xFFFFFF, false);
-            draw.drawString(Minecraft.getInstance().font, ChatFormatting.DARK_AQUA + "" + Component.translatable("text.industrialforegoing.jei.recipe.powered").getString(), 80, 6 + (Minecraft.getInstance().font.lineHeight + 2) * 3, 0xFFFFFF, false);
+            if (recipe.value().outputsLatex()) {
+                draw.drawString(Minecraft.getInstance().font, ChatFormatting.DARK_AQUA + "" + Component.translatable("text.industrialforegoing.jei.recipe.tripled_when").getString(), 80, 6 + (Minecraft.getInstance().font.lineHeight + 2) * 2, 0xFFFFFF, false);
+                draw.drawString(Minecraft.getInstance().font, ChatFormatting.DARK_AQUA + "" + Component.translatable("text.industrialforegoing.jei.recipe.powered").getString(), 80, 6 + (Minecraft.getInstance().font.lineHeight + 2) * 3, 0xFFFFFF, false);
+            }
             AssetUtil.drawAsset(draw, Minecraft.getInstance().screen, DefaultAssetProvider.DEFAULT_PROVIDER.getAsset(AssetTypes.TANK_NORMAL), 57, 1);
 
         });

--- a/src/main/java/com/buuz135/industrial/plugin/jei/category/FluidExtractorCategory.java
+++ b/src/main/java/com/buuz135/industrial/plugin/jei/category/FluidExtractorCategory.java
@@ -91,8 +91,10 @@ public class FluidExtractorCategory implements IRecipeCategory<FluidExtractorRec
     public void draw(FluidExtractorRecipe recipe, IRecipeSlotsView recipeSlotsView, GuiGraphics guiGraphics, double mouseX, double mouseY) {
         guiGraphics.drawString(Minecraft.getInstance().font, ChatFormatting.DARK_GRAY + Component.translatable("text.industrialforegoing.jei.recipe.production").getString(), 80, 6, 0xFFFFFF, false);
         guiGraphics.drawString(Minecraft.getInstance().font, ChatFormatting.DARK_GRAY + "" + recipe.output.getAmount() + Component.translatable("text.industrialforegoing.jei.recipe.mb_work").getString(), 80, 6 + (Minecraft.getInstance().font.lineHeight + 2) * 1, 0xFFFFFF, false);
-        guiGraphics.drawString(Minecraft.getInstance().font, ChatFormatting.DARK_AQUA + "" + Component.translatable("text.industrialforegoing.jei.recipe.tripled_when").getString(), 80, 6 + (Minecraft.getInstance().font.lineHeight + 2) * 2, 0xFFFFFF, false);
-        guiGraphics.drawString(Minecraft.getInstance().font, ChatFormatting.DARK_AQUA + "" + Component.translatable("text.industrialforegoing.jei.recipe.powered").getString(), 80, 6 + (Minecraft.getInstance().font.lineHeight + 2) * 3, 0xFFFFFF, false);
+        if (recipe.outputsLatex()) {
+            guiGraphics.drawString(Minecraft.getInstance().font, ChatFormatting.DARK_AQUA + "" + Component.translatable("text.industrialforegoing.jei.recipe.tripled_when").getString(), 80, 6 + (Minecraft.getInstance().font.lineHeight + 2) * 2, 0xFFFFFF, false);
+            guiGraphics.drawString(Minecraft.getInstance().font, ChatFormatting.DARK_AQUA + "" + Component.translatable("text.industrialforegoing.jei.recipe.powered").getString(), 80, 6 + (Minecraft.getInstance().font.lineHeight + 2) * 3, 0xFFFFFF, false);
+        }
     }
 
     @Override

--- a/src/main/java/com/buuz135/industrial/recipe/FluidExtractorRecipe.java
+++ b/src/main/java/com/buuz135/industrial/recipe/FluidExtractorRecipe.java
@@ -93,6 +93,10 @@ public class FluidExtractorRecipe implements Recipe<CraftingInput> {
         return ResourceLocation.fromNamespaceAndPath(Reference.MOD_ID, "fluid_extractor/" + key);
     }
 
+    public boolean outputsLatex() {
+        return output.getFluid().isSame(ModuleCore.LATEX.getSourceFluid().get());
+    }
+
     public boolean matches(Level world, BlockPos pos) {
         return input.test(new ItemStack(world.getBlockState(pos).getBlock()));
     }


### PR DESCRIPTION
Fixes InnovativeOnlineIndustries/Industrial-Foregoing#1533

Test recipe:
```
{
  "type": "industrialforegoing:fluid_extractor",
  "breakChance": 0.01,
  "defaultRecipe": false,
  "input": {
    "item": "minecraft:stone"
  },
  "output": {
    "amount": 3,
    "id": "minecraft:water"
  },
  "result": {
    "Name": "minecraft:cobblestone",
    "Properties": {
      "axis": "y"
    }
  }
}
```