### PR TITLE
[1.21] Dissolution Chamber serializer support for fluid tags

### DIFF
--- a/src/generated/resources/data/industrialforegoing/recipe/dissolution_chamber/advanced_machine_frame.json
+++ b/src/generated/resources/data/industrialforegoing/recipe/dissolution_chamber/advanced_machine_frame.json
@@ -34,7 +34,7 @@
   ],
   "inputFluid": {
     "amount": 500,
-    "id": "industrialforegoing:pink_slime"
+    "fluid": "industrialforegoing:pink_slime"
   },
   "output": {
     "count": 1,

--- a/src/generated/resources/data/industrialforegoing/recipe/dissolution_chamber/black_laser_lens.json
+++ b/src/generated/resources/data/industrialforegoing/recipe/dissolution_chamber/black_laser_lens.json
@@ -25,7 +25,7 @@
   ],
   "inputFluid": {
     "amount": 250,
-    "id": "industrialforegoing:latex"
+    "fluid": "industrialforegoing:latex"
   },
   "output": {
     "count": 1,

--- a/src/generated/resources/data/industrialforegoing/recipe/dissolution_chamber/blue_laser_lens.json
+++ b/src/generated/resources/data/industrialforegoing/recipe/dissolution_chamber/blue_laser_lens.json
@@ -25,7 +25,7 @@
   ],
   "inputFluid": {
     "amount": 250,
-    "id": "industrialforegoing:latex"
+    "fluid": "industrialforegoing:latex"
   },
   "output": {
     "count": 1,

--- a/src/generated/resources/data/industrialforegoing/recipe/dissolution_chamber/brown_laser_lens.json
+++ b/src/generated/resources/data/industrialforegoing/recipe/dissolution_chamber/brown_laser_lens.json
@@ -25,7 +25,7 @@
   ],
   "inputFluid": {
     "amount": 250,
-    "id": "industrialforegoing:latex"
+    "fluid": "industrialforegoing:latex"
   },
   "output": {
     "count": 1,

--- a/src/generated/resources/data/industrialforegoing/recipe/dissolution_chamber/cyan_laser_lens.json
+++ b/src/generated/resources/data/industrialforegoing/recipe/dissolution_chamber/cyan_laser_lens.json
@@ -25,7 +25,7 @@
   ],
   "inputFluid": {
     "amount": 250,
-    "id": "industrialforegoing:latex"
+    "fluid": "industrialforegoing:latex"
   },
   "output": {
     "count": 1,

--- a/src/generated/resources/data/industrialforegoing/recipe/dissolution_chamber/efficiency_addon_tier_1.json
+++ b/src/generated/resources/data/industrialforegoing/recipe/dissolution_chamber/efficiency_addon_tier_1.json
@@ -34,7 +34,7 @@
   ],
   "inputFluid": {
     "amount": 1000,
-    "id": "industrialforegoing:latex"
+    "fluid": "industrialforegoing:latex"
   },
   "output": {
     "components": {

--- a/src/generated/resources/data/industrialforegoing/recipe/dissolution_chamber/efficiency_addon_tier_2.json
+++ b/src/generated/resources/data/industrialforegoing/recipe/dissolution_chamber/efficiency_addon_tier_2.json
@@ -34,7 +34,7 @@
   ],
   "inputFluid": {
     "amount": 1000,
-    "id": "industrialforegoing:latex"
+    "fluid": "industrialforegoing:latex"
   },
   "output": {
     "components": {

--- a/src/generated/resources/data/industrialforegoing/recipe/dissolution_chamber/gray_laser_lens.json
+++ b/src/generated/resources/data/industrialforegoing/recipe/dissolution_chamber/gray_laser_lens.json
@@ -25,7 +25,7 @@
   ],
   "inputFluid": {
     "amount": 250,
-    "id": "industrialforegoing:latex"
+    "fluid": "industrialforegoing:latex"
   },
   "output": {
     "count": 1,

--- a/src/generated/resources/data/industrialforegoing/recipe/dissolution_chamber/green_laser_lens.json
+++ b/src/generated/resources/data/industrialforegoing/recipe/dissolution_chamber/green_laser_lens.json
@@ -25,7 +25,7 @@
   ],
   "inputFluid": {
     "amount": 250,
-    "id": "industrialforegoing:latex"
+    "fluid": "industrialforegoing:latex"
   },
   "output": {
     "count": 1,

--- a/src/generated/resources/data/industrialforegoing/recipe/dissolution_chamber/infinity_drill.json
+++ b/src/generated/resources/data/industrialforegoing/recipe/dissolution_chamber/infinity_drill.json
@@ -34,7 +34,7 @@
   ],
   "inputFluid": {
     "amount": 2000,
-    "id": "industrialforegoing:pink_slime"
+    "fluid": "industrialforegoing:pink_slime"
   },
   "output": {
     "components": {

--- a/src/generated/resources/data/industrialforegoing/recipe/dissolution_chamber/infinity_hammer.json
+++ b/src/generated/resources/data/industrialforegoing/recipe/dissolution_chamber/infinity_hammer.json
@@ -34,7 +34,7 @@
   ],
   "inputFluid": {
     "amount": 2000,
-    "id": "industrialforegoing:pink_slime"
+    "fluid": "industrialforegoing:pink_slime"
   },
   "output": {
     "components": {

--- a/src/generated/resources/data/industrialforegoing/recipe/dissolution_chamber/infinity_launcher.json
+++ b/src/generated/resources/data/industrialforegoing/recipe/dissolution_chamber/infinity_launcher.json
@@ -34,7 +34,7 @@
   ],
   "inputFluid": {
     "amount": 2000,
-    "id": "industrialforegoing:pink_slime"
+    "fluid": "industrialforegoing:pink_slime"
   },
   "output": {
     "components": {

--- a/src/generated/resources/data/industrialforegoing/recipe/dissolution_chamber/infinity_nuke.json
+++ b/src/generated/resources/data/industrialforegoing/recipe/dissolution_chamber/infinity_nuke.json
@@ -34,7 +34,7 @@
   ],
   "inputFluid": {
     "amount": 2000,
-    "id": "industrialforegoing:ether_gas"
+    "fluid": "industrialforegoing:ether_gas"
   },
   "output": {
     "components": {

--- a/src/generated/resources/data/industrialforegoing/recipe/dissolution_chamber/infinity_saw.json
+++ b/src/generated/resources/data/industrialforegoing/recipe/dissolution_chamber/infinity_saw.json
@@ -34,7 +34,7 @@
   ],
   "inputFluid": {
     "amount": 2000,
-    "id": "industrialforegoing:pink_slime"
+    "fluid": "industrialforegoing:pink_slime"
   },
   "output": {
     "components": {

--- a/src/generated/resources/data/industrialforegoing/recipe/dissolution_chamber/infinity_trident.json
+++ b/src/generated/resources/data/industrialforegoing/recipe/dissolution_chamber/infinity_trident.json
@@ -34,7 +34,7 @@
   ],
   "inputFluid": {
     "amount": 2000,
-    "id": "industrialforegoing:pink_slime"
+    "fluid": "industrialforegoing:pink_slime"
   },
   "output": {
     "components": {

--- a/src/generated/resources/data/industrialforegoing/recipe/dissolution_chamber/light_blue_laser_lens.json
+++ b/src/generated/resources/data/industrialforegoing/recipe/dissolution_chamber/light_blue_laser_lens.json
@@ -25,7 +25,7 @@
   ],
   "inputFluid": {
     "amount": 250,
-    "id": "industrialforegoing:latex"
+    "fluid": "industrialforegoing:latex"
   },
   "output": {
     "count": 1,

--- a/src/generated/resources/data/industrialforegoing/recipe/dissolution_chamber/light_gray_laser_lens.json
+++ b/src/generated/resources/data/industrialforegoing/recipe/dissolution_chamber/light_gray_laser_lens.json
@@ -25,7 +25,7 @@
   ],
   "inputFluid": {
     "amount": 250,
-    "id": "industrialforegoing:latex"
+    "fluid": "industrialforegoing:latex"
   },
   "output": {
     "count": 1,

--- a/src/generated/resources/data/industrialforegoing/recipe/dissolution_chamber/lime_laser_lens.json
+++ b/src/generated/resources/data/industrialforegoing/recipe/dissolution_chamber/lime_laser_lens.json
@@ -25,7 +25,7 @@
   ],
   "inputFluid": {
     "amount": 250,
-    "id": "industrialforegoing:latex"
+    "fluid": "industrialforegoing:latex"
   },
   "output": {
     "count": 1,

--- a/src/generated/resources/data/industrialforegoing/recipe/dissolution_chamber/magenta_laser_lens.json
+++ b/src/generated/resources/data/industrialforegoing/recipe/dissolution_chamber/magenta_laser_lens.json
@@ -25,7 +25,7 @@
   ],
   "inputFluid": {
     "amount": 250,
-    "id": "industrialforegoing:latex"
+    "fluid": "industrialforegoing:latex"
   },
   "output": {
     "count": 1,

--- a/src/generated/resources/data/industrialforegoing/recipe/dissolution_chamber/mechanical_dirt.json
+++ b/src/generated/resources/data/industrialforegoing/recipe/dissolution_chamber/mechanical_dirt.json
@@ -25,7 +25,7 @@
   ],
   "inputFluid": {
     "amount": 1000,
-    "id": "industrialforegoing:meat"
+    "fluid": "industrialforegoing:meat"
   },
   "output": {
     "count": 1,

--- a/src/generated/resources/data/industrialforegoing/recipe/dissolution_chamber/mycelial_reactor.json
+++ b/src/generated/resources/data/industrialforegoing/recipe/dissolution_chamber/mycelial_reactor.json
@@ -34,7 +34,7 @@
   ],
   "inputFluid": {
     "amount": 500,
-    "id": "industrialforegoing:ether_gas"
+    "fluid": "industrialforegoing:ether_gas"
   },
   "output": {
     "count": 1,

--- a/src/generated/resources/data/industrialforegoing/recipe/dissolution_chamber/orange_laser_lens.json
+++ b/src/generated/resources/data/industrialforegoing/recipe/dissolution_chamber/orange_laser_lens.json
@@ -25,7 +25,7 @@
   ],
   "inputFluid": {
     "amount": 250,
-    "id": "industrialforegoing:latex"
+    "fluid": "industrialforegoing:latex"
   },
   "output": {
     "count": 1,

--- a/src/generated/resources/data/industrialforegoing/recipe/dissolution_chamber/pink_laser_lens.json
+++ b/src/generated/resources/data/industrialforegoing/recipe/dissolution_chamber/pink_laser_lens.json
@@ -25,7 +25,7 @@
   ],
   "inputFluid": {
     "amount": 250,
-    "id": "industrialforegoing:latex"
+    "fluid": "industrialforegoing:latex"
   },
   "output": {
     "count": 1,

--- a/src/generated/resources/data/industrialforegoing/recipe/dissolution_chamber/pink_slime_ball.json
+++ b/src/generated/resources/data/industrialforegoing/recipe/dissolution_chamber/pink_slime_ball.json
@@ -13,7 +13,7 @@
   ],
   "inputFluid": {
     "amount": 300,
-    "id": "industrialforegoing:pink_slime"
+    "fluid": "industrialforegoing:pink_slime"
   },
   "output": {
     "count": 1,

--- a/src/generated/resources/data/industrialforegoing/recipe/dissolution_chamber/pink_slime_ingot.json
+++ b/src/generated/resources/data/industrialforegoing/recipe/dissolution_chamber/pink_slime_ingot.json
@@ -22,7 +22,7 @@
   ],
   "inputFluid": {
     "amount": 1000,
-    "id": "industrialforegoing:pink_slime"
+    "fluid": "industrialforegoing:pink_slime"
   },
   "output": {
     "count": 1,

--- a/src/generated/resources/data/industrialforegoing/recipe/dissolution_chamber/processing_addon_tier_1.json
+++ b/src/generated/resources/data/industrialforegoing/recipe/dissolution_chamber/processing_addon_tier_1.json
@@ -34,7 +34,7 @@
   ],
   "inputFluid": {
     "amount": 1000,
-    "id": "industrialforegoing:latex"
+    "fluid": "industrialforegoing:latex"
   },
   "output": {
     "components": {

--- a/src/generated/resources/data/industrialforegoing/recipe/dissolution_chamber/processing_addon_tier_2.json
+++ b/src/generated/resources/data/industrialforegoing/recipe/dissolution_chamber/processing_addon_tier_2.json
@@ -34,7 +34,7 @@
   ],
   "inputFluid": {
     "amount": 1000,
-    "id": "industrialforegoing:latex"
+    "fluid": "industrialforegoing:latex"
   },
   "output": {
     "components": {

--- a/src/generated/resources/data/industrialforegoing/recipe/dissolution_chamber/purple_laser_lens.json
+++ b/src/generated/resources/data/industrialforegoing/recipe/dissolution_chamber/purple_laser_lens.json
@@ -25,7 +25,7 @@
   ],
   "inputFluid": {
     "amount": 250,
-    "id": "industrialforegoing:latex"
+    "fluid": "industrialforegoing:latex"
   },
   "output": {
     "count": 1,

--- a/src/generated/resources/data/industrialforegoing/recipe/dissolution_chamber/range_addon_tier_0.json
+++ b/src/generated/resources/data/industrialforegoing/recipe/dissolution_chamber/range_addon_tier_0.json
@@ -34,7 +34,7 @@
   ],
   "inputFluid": {
     "amount": 1000,
-    "id": "industrialforegoing:latex"
+    "fluid": "industrialforegoing:latex"
   },
   "output": {
     "components": {

--- a/src/generated/resources/data/industrialforegoing/recipe/dissolution_chamber/range_addon_tier_1.json
+++ b/src/generated/resources/data/industrialforegoing/recipe/dissolution_chamber/range_addon_tier_1.json
@@ -34,7 +34,7 @@
   ],
   "inputFluid": {
     "amount": 1000,
-    "id": "industrialforegoing:latex"
+    "fluid": "industrialforegoing:latex"
   },
   "output": {
     "components": {

--- a/src/generated/resources/data/industrialforegoing/recipe/dissolution_chamber/range_addon_tier_10.json
+++ b/src/generated/resources/data/industrialforegoing/recipe/dissolution_chamber/range_addon_tier_10.json
@@ -34,7 +34,7 @@
   ],
   "inputFluid": {
     "amount": 1000,
-    "id": "industrialforegoing:latex"
+    "fluid": "industrialforegoing:latex"
   },
   "output": {
     "components": {

--- a/src/generated/resources/data/industrialforegoing/recipe/dissolution_chamber/range_addon_tier_11.json
+++ b/src/generated/resources/data/industrialforegoing/recipe/dissolution_chamber/range_addon_tier_11.json
@@ -34,7 +34,7 @@
   ],
   "inputFluid": {
     "amount": 1000,
-    "id": "industrialforegoing:latex"
+    "fluid": "industrialforegoing:latex"
   },
   "output": {
     "components": {

--- a/src/generated/resources/data/industrialforegoing/recipe/dissolution_chamber/range_addon_tier_2.json
+++ b/src/generated/resources/data/industrialforegoing/recipe/dissolution_chamber/range_addon_tier_2.json
@@ -34,7 +34,7 @@
   ],
   "inputFluid": {
     "amount": 1000,
-    "id": "industrialforegoing:latex"
+    "fluid": "industrialforegoing:latex"
   },
   "output": {
     "components": {

--- a/src/generated/resources/data/industrialforegoing/recipe/dissolution_chamber/range_addon_tier_3.json
+++ b/src/generated/resources/data/industrialforegoing/recipe/dissolution_chamber/range_addon_tier_3.json
@@ -34,7 +34,7 @@
   ],
   "inputFluid": {
     "amount": 1000,
-    "id": "industrialforegoing:latex"
+    "fluid": "industrialforegoing:latex"
   },
   "output": {
     "components": {

--- a/src/generated/resources/data/industrialforegoing/recipe/dissolution_chamber/range_addon_tier_4.json
+++ b/src/generated/resources/data/industrialforegoing/recipe/dissolution_chamber/range_addon_tier_4.json
@@ -34,7 +34,7 @@
   ],
   "inputFluid": {
     "amount": 1000,
-    "id": "industrialforegoing:latex"
+    "fluid": "industrialforegoing:latex"
   },
   "output": {
     "components": {

--- a/src/generated/resources/data/industrialforegoing/recipe/dissolution_chamber/range_addon_tier_5.json
+++ b/src/generated/resources/data/industrialforegoing/recipe/dissolution_chamber/range_addon_tier_5.json
@@ -34,7 +34,7 @@
   ],
   "inputFluid": {
     "amount": 1000,
-    "id": "industrialforegoing:latex"
+    "fluid": "industrialforegoing:latex"
   },
   "output": {
     "components": {

--- a/src/generated/resources/data/industrialforegoing/recipe/dissolution_chamber/range_addon_tier_6.json
+++ b/src/generated/resources/data/industrialforegoing/recipe/dissolution_chamber/range_addon_tier_6.json
@@ -34,7 +34,7 @@
   ],
   "inputFluid": {
     "amount": 1000,
-    "id": "industrialforegoing:latex"
+    "fluid": "industrialforegoing:latex"
   },
   "output": {
     "components": {

--- a/src/generated/resources/data/industrialforegoing/recipe/dissolution_chamber/range_addon_tier_7.json
+++ b/src/generated/resources/data/industrialforegoing/recipe/dissolution_chamber/range_addon_tier_7.json
@@ -34,7 +34,7 @@
   ],
   "inputFluid": {
     "amount": 1000,
-    "id": "industrialforegoing:latex"
+    "fluid": "industrialforegoing:latex"
   },
   "output": {
     "components": {

--- a/src/generated/resources/data/industrialforegoing/recipe/dissolution_chamber/range_addon_tier_8.json
+++ b/src/generated/resources/data/industrialforegoing/recipe/dissolution_chamber/range_addon_tier_8.json
@@ -34,7 +34,7 @@
   ],
   "inputFluid": {
     "amount": 1000,
-    "id": "industrialforegoing:latex"
+    "fluid": "industrialforegoing:latex"
   },
   "output": {
     "components": {

--- a/src/generated/resources/data/industrialforegoing/recipe/dissolution_chamber/range_addon_tier_9.json
+++ b/src/generated/resources/data/industrialforegoing/recipe/dissolution_chamber/range_addon_tier_9.json
@@ -34,7 +34,7 @@
   ],
   "inputFluid": {
     "amount": 1000,
-    "id": "industrialforegoing:latex"
+    "fluid": "industrialforegoing:latex"
   },
   "output": {
     "components": {

--- a/src/generated/resources/data/industrialforegoing/recipe/dissolution_chamber/red_laser_lens.json
+++ b/src/generated/resources/data/industrialforegoing/recipe/dissolution_chamber/red_laser_lens.json
@@ -25,7 +25,7 @@
   ],
   "inputFluid": {
     "amount": 250,
-    "id": "industrialforegoing:latex"
+    "fluid": "industrialforegoing:latex"
   },
   "output": {
     "count": 1,

--- a/src/generated/resources/data/industrialforegoing/recipe/dissolution_chamber/simple_machine_frame.json
+++ b/src/generated/resources/data/industrialforegoing/recipe/dissolution_chamber/simple_machine_frame.json
@@ -34,7 +34,7 @@
   ],
   "inputFluid": {
     "amount": 250,
-    "id": "industrialforegoing:latex"
+    "fluid": "industrialforegoing:latex"
   },
   "output": {
     "count": 1,

--- a/src/generated/resources/data/industrialforegoing/recipe/dissolution_chamber/speed_addon_tier_1.json
+++ b/src/generated/resources/data/industrialforegoing/recipe/dissolution_chamber/speed_addon_tier_1.json
@@ -34,7 +34,7 @@
   ],
   "inputFluid": {
     "amount": 1000,
-    "id": "industrialforegoing:latex"
+    "fluid": "industrialforegoing:latex"
   },
   "output": {
     "components": {

--- a/src/generated/resources/data/industrialforegoing/recipe/dissolution_chamber/speed_addon_tier_2.json
+++ b/src/generated/resources/data/industrialforegoing/recipe/dissolution_chamber/speed_addon_tier_2.json
@@ -34,7 +34,7 @@
   ],
   "inputFluid": {
     "amount": 1000,
-    "id": "industrialforegoing:latex"
+    "fluid": "industrialforegoing:latex"
   },
   "output": {
     "components": {

--- a/src/generated/resources/data/industrialforegoing/recipe/dissolution_chamber/supreme_machine_frame.json
+++ b/src/generated/resources/data/industrialforegoing/recipe/dissolution_chamber/supreme_machine_frame.json
@@ -34,7 +34,7 @@
   ],
   "inputFluid": {
     "amount": 135,
-    "id": "industrialforegoing:ether_gas"
+    "fluid": "industrialforegoing:ether_gas"
   },
   "output": {
     "count": 1,

--- a/src/generated/resources/data/industrialforegoing/recipe/dissolution_chamber/white_laser_lens.json
+++ b/src/generated/resources/data/industrialforegoing/recipe/dissolution_chamber/white_laser_lens.json
@@ -25,7 +25,7 @@
   ],
   "inputFluid": {
     "amount": 250,
-    "id": "industrialforegoing:latex"
+    "fluid": "industrialforegoing:latex"
   },
   "output": {
     "count": 1,

--- a/src/generated/resources/data/industrialforegoing/recipe/dissolution_chamber/xp_bottles.json
+++ b/src/generated/resources/data/industrialforegoing/recipe/dissolution_chamber/xp_bottles.json
@@ -9,7 +9,7 @@
   "input": [],
   "inputFluid": {
     "amount": 250,
-    "id": "industrialforegoing:essence"
+    "tag": "c:experience"
   },
   "output": {
     "count": 1,

--- a/src/generated/resources/data/industrialforegoing/recipe/dissolution_chamber/yellow_laser_lens.json
+++ b/src/generated/resources/data/industrialforegoing/recipe/dissolution_chamber/yellow_laser_lens.json
@@ -25,7 +25,7 @@
   ],
   "inputFluid": {
     "amount": 250,
-    "id": "industrialforegoing:latex"
+    "fluid": "industrialforegoing:latex"
   },
   "output": {
     "count": 1,

--- a/src/main/java/com/buuz135/industrial/block/core/tile/DissolutionChamberTile.java
+++ b/src/main/java/com/buuz135/industrial/block/core/tile/DissolutionChamberTile.java
@@ -47,6 +47,8 @@ import net.neoforged.neoforge.items.ItemHandlerHelper;
 import org.apache.commons.lang3.tuple.Pair;
 
 import javax.annotation.Nonnull;
+import java.util.Arrays;
+import java.util.Optional;
 
 public class DissolutionChamberTile extends IndustrialProcessingTile<DissolutionChamberTile> {
 
@@ -124,16 +126,19 @@ public class DissolutionChamberTile extends IndustrialProcessingTile<Dissolution
         return () -> {
             if (currentRecipe != null) {
                 DissolutionChamberRecipe dissolutionChamberRecipe = currentRecipe;
-                inputFluid.drainForced(dissolutionChamberRecipe.inputFluid, IFluidHandler.FluidAction.EXECUTE);
-                for (int i = 0; i < input.getInventory().getSlots(); i++) {
-                    input.getInventory().getStackInSlot(i).shrink(1);
+                Optional<FluidStack> optionalInputFluid = Arrays.stream(dissolutionChamberRecipe.inputFluid.getFluids()).findFirst();
+                if (optionalInputFluid.isPresent()) {
+                    inputFluid.drainForced(optionalInputFluid.get(), IFluidHandler.FluidAction.EXECUTE);
+                    for (int i = 0; i < input.getInventory().getSlots(); i++) {
+                        input.getInventory().getStackInSlot(i).shrink(1);
+                    }
+                    if (dissolutionChamberRecipe.outputFluid.isPresent() && !dissolutionChamberRecipe.outputFluid.get().isEmpty())
+                        outputFluid.fillForced(dissolutionChamberRecipe.outputFluid.get().copy(), IFluidHandler.FluidAction.EXECUTE);
+                    ItemStack outputStack = dissolutionChamberRecipe.output.get().copy();
+                    outputStack.getItem().onCraftedBy(outputStack, this.level, null);
+                    ItemHandlerHelper.insertItem(output, outputStack, false);
+                    checkForRecipe();
                 }
-                if (dissolutionChamberRecipe.outputFluid.isPresent() && !dissolutionChamberRecipe.outputFluid.get().isEmpty())
-                    outputFluid.fillForced(dissolutionChamberRecipe.outputFluid.get().copy(), IFluidHandler.FluidAction.EXECUTE);
-                ItemStack outputStack = dissolutionChamberRecipe.output.get().copy();
-                outputStack.getItem().onCraftedBy(outputStack, this.level, null);
-                ItemHandlerHelper.insertItem(output, outputStack, false);
-                checkForRecipe();
             }
         };
     }

--- a/src/main/java/com/buuz135/industrial/plugin/emi/recipe/CustomEmiRecipe.java
+++ b/src/main/java/com/buuz135/industrial/plugin/emi/recipe/CustomEmiRecipe.java
@@ -9,6 +9,7 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.crafting.Ingredient;
 import net.neoforged.neoforge.fluids.FluidStack;
+import net.neoforged.neoforge.fluids.crafting.SizedFluidIngredient;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.*;
@@ -45,6 +46,11 @@ public abstract class CustomEmiRecipe implements EmiRecipe {
 
     public static List<EmiIngredient> fromInput(FluidStack fluidStack) {
         return fromInput(EmiIngredient.of(Collections.singletonList(NeoForgeEmiStack.of(fluidStack))));
+    }
+
+    public static List<EmiIngredient> fromInput(SizedFluidIngredient fluidStack) {
+        Optional<FluidStack> optionalInputFluid = Arrays.stream(fluidStack.getFluids()).findFirst();
+        return optionalInputFluid.map(stack -> fromInput(EmiIngredient.of(Collections.singletonList(NeoForgeEmiStack.of(stack))))).orElseGet(ArrayList::new);
     }
 
     public static List<EmiStack> fromOutput(ItemStack output, FluidStack fluidStack) {

--- a/src/main/java/com/buuz135/industrial/plugin/emi/recipe/DissChamberEmiRecipe.java
+++ b/src/main/java/com/buuz135/industrial/plugin/emi/recipe/DissChamberEmiRecipe.java
@@ -22,6 +22,7 @@ import net.neoforged.neoforge.fluids.FluidStack;
 import org.apache.commons.lang3.tuple.Pair;
 
 import java.awt.*;
+import java.util.Arrays;
 import java.util.List;
 
 public class DissChamberEmiRecipe extends CustomEmiRecipe {

--- a/src/main/java/com/buuz135/industrial/plugin/jei/category/DissolutionChamberCategory.java
+++ b/src/main/java/com/buuz135/industrial/plugin/jei/category/DissolutionChamberCategory.java
@@ -47,11 +47,14 @@ import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.DyeColor;
 import net.minecraft.world.item.ItemStack;
+import net.neoforged.neoforge.fluids.FluidStack;
 import org.apache.commons.lang3.tuple.Pair;
 
 import java.awt.*;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
 public class DissolutionChamberCategory implements IRecipeCategory<DissolutionChamberRecipe> {
 
@@ -90,8 +93,9 @@ public class DissolutionChamberCategory implements IRecipeCategory<DissolutionCh
         for (int i = 0; i < recipe.input.size(); i++) {
             builder.addSlot(RecipeIngredientRole.INPUT, 24 + DissolutionChamberTile.getSlotPos(i).getLeft(), 11 + DissolutionChamberTile.getSlotPos(i).getRight()).addIngredients(recipe.input.get(i));
         }
-        if (recipe.inputFluid != null && !recipe.inputFluid.isEmpty()) {
-            builder.addSlot(RecipeIngredientRole.INPUT, 33 + 12 + 3, 32 + 3).setFluidRenderer(1000, false, 12, 13).setOverlay(smallTank, 0, 0).addIngredient(NeoForgeTypes.FLUID_STACK, recipe.inputFluid);
+        if (recipe.inputFluid != null && !recipe.inputFluid.ingredient().isEmpty()) {
+            Optional<FluidStack> optionalInputFluid = Arrays.stream(recipe.inputFluid.getFluids()).findFirst();
+            optionalInputFluid.ifPresent(fluidStack -> builder.addSlot(RecipeIngredientRole.INPUT, 33 + 12 + 3, 32 + 3).setFluidRenderer(1000, false, 12, 13).setOverlay(smallTank, 0, 0).addIngredient(NeoForgeTypes.FLUID_STACK, fluidStack));
         }
         if (!recipe.output.isEmpty()) {
             ItemStack stack = recipe.output.get();

--- a/src/main/java/com/buuz135/industrial/plugin/patchouli/PageDissolution.java
+++ b/src/main/java/com/buuz135/industrial/plugin/patchouli/PageDissolution.java
@@ -23,7 +23,9 @@ import net.neoforged.neoforge.fluids.FluidStack;
 import vazkii.patchouli.client.book.gui.GuiBook;
 import vazkii.patchouli.client.book.page.abstr.PageDoubleRecipeRegistry;
 
+import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
 public class PageDissolution extends PageDoubleRecipeRegistry<DissolutionChamberRecipe> {
     public final ResourceLocation patchouliTexture = ResourceLocation.fromNamespaceAndPath(Reference.MOD_ID, "textures/gui/patchouli.png");
@@ -52,8 +54,9 @@ public class PageDissolution extends PageDoubleRecipeRegistry<DissolutionChamber
                     mouseX, mouseY,
                     recipe.input.get(i));
         }
-        if (recipe.inputFluid != null && !recipe.inputFluid.isEmpty()) {
-            renderFluid(graphics, recipeX + 22, recipeY + 28, mouseX, mouseY, recipe.inputFluid);
+        if (recipe.inputFluid != null && !recipe.inputFluid.ingredient().isEmpty()) {
+            Optional<FluidStack> optionalInputFluid = Arrays.stream(recipe.inputFluid.getFluids()).findFirst();
+            optionalInputFluid.ifPresent(fluidStack -> renderFluid(graphics, recipeX + 22, recipeY + 28, mouseX, mouseY, fluidStack));
         }
         if (!recipe.output.isEmpty()) {
             ItemStack stack = recipe.output.get();

--- a/src/main/java/com/buuz135/industrial/recipe/provider/IndustrialSerializableProvider.java
+++ b/src/main/java/com/buuz135/industrial/recipe/provider/IndustrialSerializableProvider.java
@@ -35,6 +35,7 @@ import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.material.Fluids;
 import net.neoforged.neoforge.common.Tags;
 import net.neoforged.neoforge.fluids.FluidStack;
+import net.neoforged.neoforge.fluids.crafting.SizedFluidIngredient;
 
 import java.util.List;
 import java.util.Optional;
@@ -111,7 +112,7 @@ public class IndustrialSerializableProvider {
                 new FluidStack(ModuleCore.ETHER.getSourceFluid().get(), 500), 600, Optional.of(new ItemStack(ModuleGenerator.MYCELIAL_REACTOR.getBlock())), Optional.empty()));
         DissolutionChamberRecipe.createRecipe(output, "xp_bottles", new DissolutionChamberRecipe(
                 List.of(),
-                new FluidStack(ModuleCore.ESSENCE.getSourceFluid().get(), 250), 5, Optional.of(new ItemStack(Items.EXPERIENCE_BOTTLE)), Optional.empty()));
+                SizedFluidIngredient.of(IndustrialTags.Fluids.EXPERIENCE, 250), 5, Optional.of(new ItemStack(Items.EXPERIENCE_BOTTLE)), Optional.empty()));
 
         FluidExtractorRecipe.init(output);
         LaserDrillFluidRecipe.init(output);


### PR DESCRIPTION
The recipe serializer industrialforegoing:dissolution_chamber got a revamp with this commit causing it to use "fluid" instead of "id". And as a result it now supports using fluid tags in inputFluid.
This is  a *breaking* change that forces all addons/modpacks that have custom dissolution chamber recipes to update to the new format, where "id" is replaced by "fluid" in inputFluids.

Examples:
```
  "inputFluid": {
    "amount": 250,
    "tag": "c:experience"
  }
```
```
  "inputFluid": {
    "amount": 1000,
    "fluid": "industrialforegoing:latex"
  }
```

Also changed the recipe for minecraft:experience_bottle to use the fluid tag c:experience instead of industrialforegoing:essence.