### PR TITLE
Allow potion brewer output if no filter is specified

### DIFF
--- a/src/main/java/com/buuz135/industrial/block/resourceproduction/tile/PotionBrewerTile.java
+++ b/src/main/java/com/buuz135/industrial/block/resourceproduction/tile/PotionBrewerTile.java
@@ -142,7 +142,7 @@ public class PotionBrewerTile extends IndustrialProcessingTile<PotionBrewerTile>
                 //.setRange(1,3)
                 .setSlotLimit(1)
                 .setInputFilter((stack, integer) -> false)
-                .setOutputFilter((stack, integer) -> this.filter.matches(stack))
+                .setOutputFilter((stack, integer) -> filterSlot.getFilter().isEmpty() || this.filter.matches(stack))
         );
     }
 


### PR DESCRIPTION
Allows slot extraction from the output slots when the filter slot is empty. Fixes reliance on the "push" action for output, and allows external automation sources to extract more than one type of item.

I figured it would be more appropriate to modify this directly in the potion brewer rather than looking into [Titanium](https://github.com/InnovativeOnlineIndustries/Titanium).