### PR TITLE
Change depth mask back to true after rendering

### DIFF
--- a/src/main/java/com/buuz135/industrial/proxy/client/render/MycelialReactorTESR.java
+++ b/src/main/java/com/buuz135/industrial/proxy/client/render/MycelialReactorTESR.java
@@ -58,6 +58,7 @@ public class MycelialReactorTESR implements BlockEntityRenderer<MycelialReactorT
                     RenderSystem.blendFunc(GlStateManager.SourceFactor.SRC_ALPHA, GlStateManager.DestFactor.SRC_ALPHA);
                 }, () -> {
                     RenderSystem.disableBlend();
+                    RenderSystem.depthMask(true);
                 })).createCompositeState(true);
         return RenderType.create("mycelial_render", DefaultVertexFormat.POSITION_TEX_COLOR, VertexFormat.Mode.QUADS, 262144, false, true, state);
     }

--- a/src/main/java/com/buuz135/industrial/proxy/client/render/WorkingAreaTESR.java
+++ b/src/main/java/com/buuz135/industrial/proxy/client/render/WorkingAreaTESR.java
@@ -54,6 +54,7 @@ public class WorkingAreaTESR implements BlockEntityRenderer<IndustrialAreaWorkin
                     RenderSystem.blendFuncSeparate(GlStateManager.SourceFactor.SRC_ALPHA, GlStateManager.DestFactor.ONE_MINUS_SRC_ALPHA, GlStateManager.SourceFactor.ONE, GlStateManager.DestFactor.ONE_MINUS_SRC_ALPHA);
                 }, () -> {
                     RenderSystem.disableBlend();
+                    RenderSystem.depthMask(true);
                     RenderSystem.defaultBlendFunc();
                 })).createCompositeState(true);
         return RenderType.create("working_area_render", DefaultVertexFormat.POSITION_COLOR, VertexFormat.Mode.QUADS, 256, false, true, state);


### PR DESCRIPTION
Fixes #1562 and https://github.com/RaphiMC/ImmediatelyFast/issues/337

While this is technically an ImmediatelyFast issue, I decided to fix it in Industrial Foregoing. The code in Industrial Foregoing isn't correct and ImmediatelyFast causes the issue to be visible. Without ImmediatelyFast the issue happens as well, but at a different place in rendering, after the chests are rendered (It doesn't really affect anything in vanilla because the Industrial Foregoing code is called pretty much last). ImmediatelyFast slightly reorders the render calls which causes the issue to be visible.