### PR TITLE
Fixed tags in sand to silicon crush recipe

### DIFF
--- a/src/generated/resources/data/industrialforegoing/advancement/crusher/sand.json
+++ b/src/generated/resources/data/industrialforegoing/advancement/crusher/sand.json
@@ -4,7 +4,7 @@
       "type": "neoforge:not",
       "value": {
         "type": "neoforge:tag_empty",
-        "tag": "c:silicons"
+        "tag": "c:silicon"
       }
     }
   ],

--- a/src/generated/resources/data/industrialforegoing/recipe/crusher/sand.json
+++ b/src/generated/resources/data/industrialforegoing/recipe/crusher/sand.json
@@ -4,13 +4,13 @@
       "type": "neoforge:not",
       "value": {
         "type": "neoforge:tag_empty",
-        "tag": "c:silicons"
+        "tag": "c:silicon"
       }
     }
   ],
   "type": "industrialforegoing:crusher",
   "input": {
-    "tag": "c:sand"
+    "tag": "c:sands"
   },
   "output": {
     "tag": "c:silicon"

--- a/src/main/java/com/buuz135/industrial/recipe/CrusherRecipe.java
+++ b/src/main/java/com/buuz135/industrial/recipe/CrusherRecipe.java
@@ -71,7 +71,7 @@ public class CrusherRecipe implements Recipe<CraftingInput> {
     public static void init(RecipeOutput output) {
         createRecipe(output, "cobblestone", new CrusherRecipe(Ingredient.of(TagUtil.getItemTag(ResourceLocation.fromNamespaceAndPath("c", "cobblestones/normal"))), Ingredient.of(Items.GRAVEL)));
         createRecipe(output, "gravel", new CrusherRecipe(Ingredient.of(TagUtil.getItemTag(ResourceLocation.fromNamespaceAndPath("c", "gravels"))), Ingredient.of(Items.SAND)));
-        createRecipe(output, "sand", new CrusherRecipe(Ingredient.of(TagUtil.getItemTag(ResourceLocation.fromNamespaceAndPath("c", "sand"))), Ingredient.of(TagUtil.getItemTag(ResourceLocation.fromNamespaceAndPath("c", "silicon"))), ResourceLocation.fromNamespaceAndPath("c", "silicons")));
+        createRecipe(output, "sand", new CrusherRecipe(Ingredient.of(TagUtil.getItemTag(ResourceLocation.fromNamespaceAndPath("c", "sands"))), Ingredient.of(TagUtil.getItemTag(ResourceLocation.fromNamespaceAndPath("c", "silicon"))), ResourceLocation.fromNamespaceAndPath("c", "silicon")));
     }
 
     public static void createRecipe(RecipeOutput recipeOutput, String name, CrusherRecipe recipe) {


### PR DESCRIPTION
Fixed tags, for silicon craft, `c:sand`->`c:sands` and `c:silicons`->`c:silicon`